### PR TITLE
fix: Ens metadata

### DIFF
--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -382,6 +382,7 @@ def convert_to_fieldlist(
     if ensemble_member is not None and ensemble_member >= 1:
         metadata.update(
             {
+                "productDefinitionTemplateNumber": 1,
                 "type": "pf",
                 "stream": "enfo",
                 "number": ensemble_member,


### PR DESCRIPTION
### Description
Add  "productDefinitionTemplateNumber":1 to ens metadata

Closes https://github.com/ecmwf/forecast-in-a-box/issues/141

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 