### PR TITLE
feat: Seperate inference deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,8 @@ repos:
   - id: isort
     args:
     - -l 120
-    - --force-single-line-imports
     - --profile black
-    - --project anemoi
+    - --project earthkit
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.8.1
   hooks:

--- a/README.md
+++ b/README.md
@@ -25,13 +25,37 @@ Earthkit-Workflows-Anemoi is a Python library for connecting [anemoi-inference](
 
 ## Installation
 
-Install via `pip` with:
+The package has a split dependency structure to allow flexible installation:
+
+### For workflow creation (minimal)
+
+To create workflows without running them locally:
 
 ```bash
-pip install 'earthkit-workflows-anemoi[all]'
+pip install earthkit-workflows-anemoi
 ```
 
-For development, you can use `pip install -e .` Additionally you may want to install pre-commit hooks via
+This installs only the core dependencies needed to define and serialize workflows.
+
+### For workflow execution (full runtime)
+
+To both create and execute workflows locally:
+
+```bash
+pip install 'earthkit-workflows-anemoi[runtime]'
+```
+
+This includes `anemoi-inference` and `anemoi-datasets` required for local execution.
+
+### For development
+
+```bash
+git clone https://github.com/ecmwf/earthkit-workflows-anemoi.git
+cd earthkit-workflows-anemoi
+pip install -e '.[dev]'
+```
+
+Additionally you may want to install pre-commit hooks:
 
 ```bash
 pip install pre-commit

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,6 +118,11 @@ todo_include_todos = not read_the_docs_build
 
 autodoc_member_order = "bysource"  # Keep file order
 
+# Mock imports for optional dependencies (runtime group)
+autodoc_mock_imports = [
+    "anemoi.inference",
+    "anemoi.datasets",
+]
 
 # https://autodoc-pydantic.readthedocs.io/en/stable/users/configuration.html
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -4,18 +4,56 @@
  Installing
 ############
 
-To install the package, you can use the following command:
+The package has a split dependency structure to support different use
+cases:
+
+********************
+ Basic Installation
+********************
+
+For workflow creation without local execution:
 
 .. code:: bash
 
    pip install earthkit-workflows-anemoi
 
-**************
- Contributing
-**************
+This installs only the core dependencies needed to define and serialize
+workflows. This is useful when workflows will be executed remotely or
+when you only need to construct workflow definitions.
+
+**********************
+ Runtime Installation
+**********************
+
+For both workflow creation and local execution:
 
 .. code:: bash
 
-   git clone ...
+   pip install 'earthkit-workflows-anemoi[runtime]'
+
+This includes the optional runtime dependencies:
+
+-  ``anemoi-inference>=0.7`` - Required for running inference tasks
+-  ``anemoi-datasets>=0.5.21`` - Required for dataset creation tasks
+
+**************************
+ Development Installation
+**************************
+
+For contributing to the project:
+
+.. code:: bash
+
+   git clone https://github.com/ecmwf/earthkit-workflows-anemoi.git
    cd earthkit-workflows-anemoi
-   pip install .[dev]
+   pip install -e '.[dev]'
+
+This installs the package in editable mode with all development
+dependencies including tests and documentation tools.
+
+.. note::
+
+   The split dependency structure allows you to create workflows in
+   environments where the full runtime dependencies (which can be large)
+   are not needed, while still being able to serialize and submit
+   workflows for remote execution.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -10,3 +10,32 @@ This allows inference tasks to be run as part of a larger DAG. It
 provides an API to directly create a graph consisting of initial
 condition retrieval and model execution, or to run inference off other
 source nodes which themselves are the initial conditions.
+
+**************
+ Architecture
+**************
+
+The package is designed with a split dependency structure:
+
+**Core Dependencies**
+
+The base installation includes only:
+
+-  ``anemoi-utils`` - Utility functions
+-  ``earthkit-workflows>=0.7`` - Workflow framework
+-  ``qubed>=0.3`` - Multi-dimensional data structure support
+
+**Runtime Dependencies (Optional)**
+
+For local workflow execution, install with ``[runtime]`` extra:
+
+-  ``anemoi-inference>=0.7`` - AI weather model inference
+-  ``anemoi-datasets>=0.5.21`` - Dataset creation and management
+
+This separation allows:
+
+#. **Lightweight workflow creation**: Create and serialize workflows
+   without heavy ML dependencies
+#. **Remote execution**: Define workflows on lightweight machines,
+   execute on compute infrastructure
+#. **Flexible deployment**: Install only what you need for your use case

--- a/docs/usage/inference.rst
+++ b/docs/usage/inference.rst
@@ -19,21 +19,20 @@ the following code:
 
    CKPT = {"huggingface": "ecmwf/aifs-single-1.0"}
 
-   model_action = anemoi_workflows.fluent.from_input(
-       CKPT, "mars", "2022-01-01T00:00", lead_time="7D"
-   )
+   inference = anemoi_workflows.fluent.Inference(CKPT, lead_time="7D")
+   model_action = inference.from_input("mars", "2022-01-01T00:00")
    model_action
 
-This will use load the checkpoint, and use the ``mars`` input source,
-with a lead_time of 7 days. It is possible to configure the input source
-just like you would do with the ``anemoi-inference`` interfaces.
+This will load the checkpoint and use the ``mars`` input source, with a
+lead time of 7 days. It is possible to configure the input source just
+like you would do with the ``anemoi-inference`` interfaces.
 
 *************
  From Source
 *************
 
 If more complex initial conditions are required, you can use the
-``infer`` method on an existing source node.
+``from_initial_conditions`` method on an ``Inference`` instance.
 
 .. code:: python
 
@@ -43,7 +42,8 @@ If more complex initial conditions are required, you can use the
    SOURCE_NODES: fluent.Action
    CKPT = {"huggingface": "ecmwf/aifs-single-1.0"}
 
-   SOURCE_NODES.anemoi.infer(CKPT, lead_time="7D")
+   inference = anemoi_workflows.fluent.Inference(CKPT, lead_time="7D")
+   inference.from_initial_conditions(SOURCE_NODES)
 
 This will use the existing source nodes as the initial conditions, and
 run the inference task with the specified checkpoint, lead time. If the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.runtime = [
   "anemoi-inference>=0.7",
 ]
 
-optional-dependencies.tests = [ "pytest", "pytest-mock", "pytest-xdist" ]
+optional-dependencies.tests = [ "earthkit-workflows-anemoi[runtime]", "pytest", "pytest-mock", "pytest-xdist" ]
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ classifiers = [
 dynamic = [ "version" ]
 
 dependencies = [
-  "anemoi-datasets>=0.5.21",
-  "anemoi-inference>=0.7",
   "earthkit-workflows>=0.7",
   "qubed>=0.3",
 ]
@@ -45,6 +43,10 @@ optional-dependencies.docs = [
   "sphinx>8.2",
   "sphinx-argparse<0.5",
   "sphinx-rtd-theme",
+]
+optional-dependencies.runtime = [
+  "anemoi-datasets>=0.5.21",
+  "anemoi-inference>=0.7",
 ]
 
 optional-dependencies.tests = [ "pytest", "pytest-mock", "pytest-xdist" ]
@@ -71,5 +73,3 @@ log_cli = true
 log_cli_level = "DEBUG"
 testpaths = [ "tests/" ]
 addopts = "-n8"
-
-[tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dynamic = [ "version" ]
 
 dependencies = [
+  "anemoi-utils",
   "earthkit-workflows>=0.7",
   "qubed>=0.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,13 @@ optional-dependencies.runtime = [
   "anemoi-inference>=0.7",
 ]
 
-optional-dependencies.tests = [ "earthkit-workflows-anemoi[runtime]", "pytest", "pytest-mock", "pytest-xdist" ]
+[dependency-groups]
+dev = [
+  "earthkit-workflows-anemoi[runtime]",
+  "pytest>=9.0.3",
+  "pytest-mock>=3.15.1",
+  "pytest-xdist>=3.8",
+]
 
 [tool.setuptools]
 include-package-data = true
@@ -74,3 +80,6 @@ log_cli = true
 log_cli_level = "DEBUG"
 testpaths = [ "tests/" ]
 addopts = "-n8"
+
+[tool.uv.sources]
+earthkit-workflows-anemoi = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,11 @@ optional-dependencies.runtime = [
   "anemoi-datasets>=0.5.21",
   "anemoi-inference>=0.7",
 ]
+optional-dependencies.tests = [ "earthkit-workflows-anemoi[runtime]", "pytest", "pytest-mock", "pytest-xdist" ]
 
 [dependency-groups]
 dev = [
-  "earthkit-workflows-anemoi[runtime]",
-  "pytest>=9.0.3",
-  "pytest-mock>=3.15.1",
-  "pytest-xdist>=3.8",
+  "earthkit-workflows-anemoi[tests]",
 ]
 
 [tool.setuptools]

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -18,17 +18,13 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from earthkit.data.utils.dates import to_datetime, to_timedelta
+from anemoi.utils.dates import as_timedelta
+from earthkit.data.utils.dates import to_datetime
 
 from earthkit.workflows import fluent
 
 from .types import ENSEMBLE_DIMENSION_NAME
-from .utils import crack_environment, expansion_qube, faked_ensemble_transform, parse_ensemble_members
-
-# from earthkit.workflows.plugins.anemoi.inference import _get_initial_conditions_source
-# from earthkit.workflows.plugins.anemoi.inference import run_model
-# from earthkit.workflows.plugins.anemoi.runner import CascadeRunner
-
+from .utils import crack_environment, expansion_qube_from_metadata, faked_ensemble_transform, parse_ensemble_members
 
 if TYPE_CHECKING:
     # anemoi-inference imports
@@ -40,6 +36,16 @@ if TYPE_CHECKING:
     from .types import DATE, ENSEMBLE_MEMBER_SPECIFICATION, ENVIRONMENT, LEAD_TIME, VALID_CKPT
 
 LOG = logging.getLogger(__name__)
+
+
+def _get_metadata(ckpt: VALID_CKPT, *, metadata: Metadata | None = None) -> Metadata:
+    if metadata is not None:
+        return metadata
+
+    from anemoi.inference.checkpoint import Checkpoint
+
+    checkpoint = Checkpoint(ckpt)  # type: ignore
+    return checkpoint._metadata
 
 
 def _get_initial_conditions_source(
@@ -174,7 +180,7 @@ def _run_model(
     fluent.Action
         Cascade action of the model results
     """
-    lead_time = to_timedelta(lead_time)
+    lead_time = as_timedelta(lead_time)
 
     model_payload = fluent.Payload(
         "earthkit.workflows.plugins.anemoi.inference.run_as_earthkit_from_config",
@@ -183,7 +189,7 @@ def _run_model(
         metadata=payload_metadata,
     )
 
-    qube = expansion_qube(metadata, lead_time)
+    qube = expansion_qube_from_metadata(metadata, lead_time)
     model_results = input_state_source.map(model_payload, yields=("step", list(qube.axes()["step"])))
     return model_results.expand_as_qube(qube.remove_by_key("step"))
 
@@ -266,7 +272,7 @@ def from_config(
     )
 
     return _run_model(
-        metadata,  # TODO Figure out how to get the metadata here
+        _get_metadata(configuration.checkpoint, metadata=None),  # type: ignore
         configuration,
         input_state_source,
         configuration.lead_time,
@@ -282,6 +288,7 @@ def from_input(
     *,
     ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
     environment: ENVIRONMENT | None = None,
+    metadata: Metadata | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -308,6 +315,8 @@ def from_input(
         e.g. `["anemoi-models==0.3.1"]`
         Can be dict[str, list[str]] with keys `inference` and `initial_conditions`
         to set the environment for each part of the run.
+    metadata : Optional[Metadata], optional
+        `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
     kwargs : dict
         Additional arguments to pass to the configuration
 
@@ -332,7 +341,7 @@ def from_input(
     )
 
     return _run_model(
-        metadata,  # TODO Figure out how to get the metadata here
+        _get_metadata(ckpt, metadata=metadata),
         config,
         input_state_source,
         lead_time,
@@ -344,10 +353,10 @@ def from_initial_conditions(
     ckpt: VALID_CKPT,
     initial_conditions: State | fluent.Action | fluent.Payload | Callable,
     lead_time: LEAD_TIME,
-    configuration_kwargs: dict[str, Any] | None = None,
     *,
     ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
     environment: ENVIRONMENT | None = None,
+    metadata: Metadata | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -365,8 +374,6 @@ def from_initial_conditions(
     lead_time : LEAD_TIME
         Lead time to run out to. Can be a string,
         i.e. `1H`, `1D`, int, or a datetime.timedelta
-    configuration_kwargs: dict[str, Any]:
-        kwargs for `anemoi.inference` configuration
     ensemble_members : Optional[ENSEMBLE_MEMBER_SPECIFICATION], optional
         Number of ensemble members to run,
         If initial_conditions is a fluent action, with
@@ -378,6 +385,8 @@ def from_initial_conditions(
         If None, will use the current environment
         Should be set to strings, as if used in pip install,
         e.g. `["anemoi-models==0.3.1"]`
+    metadata : Optional[Metadata], optional
+        `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
     kwargs : dict
         Additional arguments to pass to the configuration
 
@@ -392,7 +401,7 @@ def from_initial_conditions(
     >>> from_initial_conditions("anemoi_model.ckpt", init_conditions, lead_time = "10D")
     """
 
-    config = dict(checkpoint=ckpt, **(configuration_kwargs or {}))
+    config = dict(checkpoint=ckpt, **kwargs)
     environment_dict = crack_environment(environment, ["inference"])
 
     if isinstance(initial_conditions, fluent.Action):
@@ -419,7 +428,7 @@ def from_initial_conditions(
             (ENSEMBLE_DIMENSION_NAME, parse_ensemble_members(ensemble_members)),  # type: ignore
         )
     return _run_model(
-        metadata,  # TODO Figure out how to get the metadata here
+        _get_metadata(ckpt, metadata=metadata),
         config,
         ens_initial_conditions,
         lead_time,
@@ -577,6 +586,7 @@ def from_dataset(
     input_template: dict[str, Any] | None = None,
     number_of_dataset_tasks: int | None = None,
     environment: ENVIRONMENT | None = None,
+    metadata: Metadata | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -612,6 +622,8 @@ def from_dataset(
         e.g. `["anemoi-models==0.3.1"]`
         Can be dict[str, list[str]] with keys `inference`, `initial_conditions`, and `dataset`
         to set the environment for each part of the run.
+    metadata : Optional[Metadata], optional
+        `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
     kwargs : dict
         Additional arguments to pass to the runner
 
@@ -629,17 +641,18 @@ def from_dataset(
 
     import yaml
 
-    if not isinstance(dataset_config, os.PathLike):
+    if not isinstance(dataset_config, dict):
         dataset_config = yaml.safe_load(open(dataset_config))
 
-    checkpoint = Checkpoint(ckpt)
+    # TODO: Get the metadata from the checkpoint without loading the whole checkpoint,
+    checkpoint = Checkpoint(ckpt)  # type: ignore
 
     dates = list(map(lambda x: to_datetime(date) + x, checkpoint.lagged))
     end_date = max(dates)
     start_date = min(dates)
     frequency = checkpoint.timestep
 
-    dataset_config["dates"] = {
+    dataset_config["dates"] = {  # type: ignore
         "start": start_date.strftime("%Y-%m-%dT%H:%M:%S"),
         "end": end_date.strftime("%Y-%m-%dT%H:%M:%S"),
         "frequency": str(frequency),
@@ -695,7 +708,7 @@ def from_dataset(
         payload_metadata={"environment": environment["initial_conditions"]},
     )
     return _run_model(
-        metadata,  # TODO Figure out how to get the metadata here
+        _get_metadata(ckpt, metadata=metadata),
         runner_config,
         input_state_source,
         lead_time,
@@ -710,7 +723,9 @@ class Action(fluent.Action):
         self,
         ckpt: VALID_CKPT,
         lead_time: LEAD_TIME,
-        configuration_kwargs: dict[str, Any] | None = None,
+        *,
+        ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+        metadata: Metadata | None = None,
         environment: ENVIRONMENT | None = None,
         **kwargs,
     ) -> fluent.Action:
@@ -724,15 +739,17 @@ class Action(fluent.Action):
         lead_time : LEAD_TIME
             Lead time to run out to. Can be a string,
             i.e. `1H`, `1D`, int, or a datetime.timedelta
-        configuration_kwargs: dict[str, Any]:
-            kwargs for anemoi.inference configuration
+        ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION | None, optional
+            Number of ensemble members to run, If set to None, the number of ensemble members will be inferred from the action. by default None.
+        metadata : Metadata | None, optional
+            `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
         environment : Optional[list[str]], optional
             Environment to run the model in, by default None
             If None, will use the current environment
             Should be set to strings, as if used in pip install,
             e.g. `["anemoi-models==0.3.1"]`
         kwargs : dict
-            Additional arguments to pass to the runner
+            Additional arguments to pass to the configuration
 
 
         Returns
@@ -741,7 +758,13 @@ class Action(fluent.Action):
             Cascade action of the model results
         """
         return from_initial_conditions(
-            ckpt, self, lead_time, configuration_kwargs=configuration_kwargs, environment=environment, **kwargs
+            ckpt,
+            self,
+            lead_time,
+            ensemble_members=ensemble_members,
+            environment=environment,
+            metadata=metadata,
+            **kwargs,
         )
 
 

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -28,7 +28,6 @@ from .utils import crack_environment, expansion_qube_from_metadata, faked_ensemb
 
 if TYPE_CHECKING:
     # anemoi-inference imports
-    from anemoi.inference.checkpoint import Checkpoint
     from anemoi.inference.config.run import RunConfiguration
     from anemoi.inference.metadata import Metadata
     from anemoi.inference.types import State
@@ -450,7 +449,7 @@ def create_dataset(
 
     Parameters
     ----------
-    config : dict[str, Any] | os.PathLike | sre
+    config : dict[str, Any] | os.PathLike | str
         Configuration to use
     path : os.PathLike | str
         Path to save the dataset to
@@ -645,6 +644,10 @@ def from_dataset(
         dataset_config = yaml.safe_load(open(dataset_config))
 
     # TODO: Get the metadata from the checkpoint without loading the whole checkpoint,
+    try:
+        from anemoi.inference.checkpoint import Checkpoint
+    except ImportError as e:
+        raise ImportError("Using `from_dataset` requires `anemoi-inference` to be installed.") from e
     checkpoint = Checkpoint(ckpt)  # type: ignore
 
     dates = list(map(lambda x: to_datetime(date) + x, checkpoint.lagged))

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -8,7 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 """
-Fluent API for anemoi inference.
+Fluent API for anemoi-inference.
 """
 
 from __future__ import annotations
@@ -16,113 +16,176 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
-from typing import TYPE_CHECKING
-from typing import Any
-from typing import TypeVar
+from typing import TYPE_CHECKING, Any
 
-from anemoi.inference.checkpoint import Checkpoint
-from anemoi.inference.config.run import RunConfiguration
-from anemoi.inference.types import State
-from earthkit.data.utils.dates import to_datetime
+from earthkit.data.utils.dates import to_datetime, to_timedelta
 
 from earthkit.workflows import fluent
-from earthkit.workflows.plugins.anemoi.inference import _parse_ensemble_members
-from earthkit.workflows.plugins.anemoi.inference import _transform_fake
-from earthkit.workflows.plugins.anemoi.inference import get_initial_conditions_source
-from earthkit.workflows.plugins.anemoi.inference import run_model
-from earthkit.workflows.plugins.anemoi.runner import CascadeRunner
-from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+from .types import ENSEMBLE_DIMENSION_NAME
+from .utils import crack_environment, expansion_qube, faked_ensemble_transform, parse_ensemble_members
+
+# from earthkit.workflows.plugins.anemoi.inference import _get_initial_conditions_source
+# from earthkit.workflows.plugins.anemoi.inference import run_model
+# from earthkit.workflows.plugins.anemoi.runner import CascadeRunner
+
 
 if TYPE_CHECKING:
-    from earthkit.workflows.plugins.anemoi.types import DATE
-    from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_MEMBER_SPECIFICATION
-    from earthkit.workflows.plugins.anemoi.types import ENVIRONMENT
-    from earthkit.workflows.plugins.anemoi.types import LEAD_TIME
-    from earthkit.workflows.plugins.anemoi.types import VALID_CKPT
+    # anemoi-inference imports
+    from anemoi.inference.checkpoint import Checkpoint
+    from anemoi.inference.config.run import RunConfiguration
+    from anemoi.inference.metadata import Metadata
+    from anemoi.inference.types import State
+
+    from .types import DATE, ENSEMBLE_MEMBER_SPECIFICATION, ENVIRONMENT, LEAD_TIME, VALID_CKPT
 
 LOG = logging.getLogger(__name__)
-E = TypeVar("E", bound=list[str] | dict[str, list[str]])
 
 
-def _parse_checkpoint(ckpt: VALID_CKPT) -> str | dict[str, Any]:
+def _get_initial_conditions_source(
+    config: RunConfiguration | dict | fluent.Action,
+    date: DATE,
+    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+    *,
+    initial_condition_perturbation: bool = False,
+    payload_metadata: dict[str, Any] | None = None,
+) -> fluent.Action:
     """
-    Parse the checkpoint to a string or dictionary.
+    Get the initial conditions for the model
 
     Parameters
     ----------
-    ckpt : VALID_CKPT
-        Checkpoint to parse
+    config : RunConfiguration | fluent.Action
+        Configuration object, must contain checkpoint and input.
+        If is a fluent action, the action must return the RunConfiguration object.
+    date : str | tuple[int, int, int]
+        Date to get initial conditions for
+    ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
+        Number of ensemble members to get, by default None
+    initial_condition_perturbation : bool, optional
+        Whether to get perturbed initial conditions, by default False
+        If False, only one initial condition is returned, and
+        the ensemble members are simulated by wrapping the action.
+    payload_metadata : Optional[dict[str, Any]], optional
+        Metadata to add to the payload, by default None
 
     Returns
     -------
-    str | dict[str, Any]
-        Parsed checkpoint
+    fluent.Action
+        Fluent action of the initial conditions
     """
-    if isinstance(ckpt, os.PathLike):
-        return str(ckpt)
-    elif isinstance(ckpt, dict):
-        return ckpt
+    ens_members = parse_ensemble_members(ensemble_members)
+    if initial_condition_perturbation:
+        if any(ens is None for ens in ens_members):
+            raise ValueError("Ensemble members must be specified when using initial condition perturbation.")
+        if isinstance(config, fluent.Action):
+            init_conditions = config.transform(
+                lambda x, *a: x.map(
+                    fluent.Payload(
+                        "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config",
+                        args=(fluent.Node.input_name(0)),
+                        kwargs=dict(ens_num=a[0], date=date),
+                        metadata=payload_metadata,
+                    )
+                ),
+                params=ens_members,
+                dim=(ENSEMBLE_DIMENSION_NAME, ens_members),
+            )
+            init_conditions._add_dimension("date", [to_datetime(date)])
+            return init_conditions
+
+        return fluent.from_source(
+            [
+                [
+                    # fluent.Payload(_get_initial_conditions_ens, kwargs=dict(input=input, date=date, ens_mem=ens_mem))
+                    fluent.Payload(
+                        "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config",
+                        kwargs=dict(config=config, date=date, ens_mem=ens_mem),
+                        metadata=payload_metadata,
+                    )
+                    for ens_mem in ens_members
+                ],
+            ],  # type: ignore
+            coords={"date": [to_datetime(date)], ENSEMBLE_DIMENSION_NAME: ens_members},
+        )
+
+    if isinstance(config, fluent.Action):
+        init_condition = fluent.Payload(
+            "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config",
+            args=(fluent.Node.input_name(0),),
+            kwargs=dict(date=date),
+            metadata=payload_metadata,
+        )
+        single_init = config.map(init_condition)
+        single_init._add_dimension("date", [to_datetime(date)])
     else:
-        raise TypeError(f"Invalid type for checkpoint: {type(ckpt)}. Must be os.PathLike or dict.")
+        init_condition = fluent.Payload(
+            "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config",
+            kwargs=dict(config=config, date=date),
+            metadata=payload_metadata,
+        )
+        single_init = fluent.from_source(
+            [
+                init_condition,
+            ],  # type: ignore
+            coords={"date": [to_datetime(date)]},
+        )
+
+    # Wrap with empty payload to simulate ensemble members
+    expanded_init = single_init.transform(
+        faked_ensemble_transform,
+        list(zip(ens_members)),
+        (ENSEMBLE_DIMENSION_NAME, ens_members),  # type: ignore
+    )
+    if ENSEMBLE_DIMENSION_NAME not in expanded_init.nodes.coords:
+        expanded_init.nodes = expanded_init.nodes.expand_dims(ENSEMBLE_DIMENSION_NAME)
+    return expanded_init
 
 
-def _add_self_to_environment(environment: E) -> E:
+def _run_model(
+    metadata: Metadata,
+    config: RunConfiguration | dict,
+    input_state_source: fluent.Action,
+    lead_time: LEAD_TIME,
+    payload_metadata: dict[str, Any] | None = None,
+    **kwargs,
+) -> fluent.Action:
     """
-    Add earthkit-workflows-anemoi to the environment list.
+    Run the model, expanding the results to the correct dimensions.
 
     Parameters
     ----------
-    environment : list[str] | dict[str, list[str]]
-        Environment list to self in place to
+    metadata : Metadata
+        `anemoi.inference` metadata
+    config : RunConfiguration | dict
+        Configuration object
+    input_state_source : fluent.Action
+        Fluent action of initial conditions
+    lead_time : LEAD_TIME
+        Lead time to run out to. Can be a string,
+        i.e. `1H`, `1D`, int, or a datetime.timedelta
+    payload_metadata : Optional[dict[str, Any]], optional
+        Metadata to add to the payload, by default None
+    kwargs : dict
+        Additional arguments to pass to the runner
 
     Returns
     -------
-    list[str] | dict[str, list[str]]
-        Environment list with self added
+    fluent.Action
+        Cascade action of the model results
     """
+    lead_time = to_timedelta(lead_time)
 
-    from earthkit.workflows.plugins.anemoi import __version__ as version
+    model_payload = fluent.Payload(
+        "earthkit.workflows.plugins.anemoi.inference.run_as_earthkit_from_config",
+        args=(fluent.Node.input_name(0),),
+        kwargs=dict(config=config, lead_time=lead_time, **kwargs),
+        metadata=payload_metadata,
+    )
 
-    if version.split(".")[-1].startswith("dev"):
-        # If the version is a development version, ignore it
-        # such that it is not overwritten
-        # e.g. "0.3.1.dev0" -> "0.3"
-        return environment
-
-    version = ".".join(version.split(".")[:3])  # Ensure version is in x.y.z format
-
-    package_name = "earthkit-workflows-anemoi"
-    self_var = f"{package_name}~={version}"
-
-    def add_self_to_list(env_list: list[str]) -> list[str]:
-        if len(env_list) == 0:
-            # If the environment is empty, leave it as such
-            return []
-
-        if any(str(e).startswith(package_name) for e in env_list):
-            # If the environment already contains the self variable, return it as is
-            return env_list
-        env_list.append(self_var)
-        return env_list
-
-    if isinstance(environment, list):
-        environment = add_self_to_list(environment)
-    elif isinstance(environment, dict):
-        for key in environment:
-            environment[key] = add_self_to_list(environment[key])
-    return environment
-
-
-def _crack_environment(environment: ENVIRONMENT, keys: list[str]) -> dict[str, list[str]]:
-    """Crack the environment into a dictionary of lists."""
-    if environment is None:
-        return _add_self_to_environment({k: [] for k in keys})
-    elif isinstance(environment, list):
-        return _add_self_to_environment({k: environment for k in keys})
-    elif isinstance(environment, dict):
-        return _add_self_to_environment({k: environment.get(k, []) for k in keys})
-    else:
-        raise TypeError(f"Invalid type for environment: {type(environment)}. Must be list or dict.")
+    qube = expansion_qube(metadata, lead_time)
+    model_results = input_state_source.map(model_payload, yields=("step", list(qube.axes()["step"])))
+    return model_results.expand_as_qube(qube.remove_by_key("step"))
 
 
 def from_config(
@@ -130,16 +193,16 @@ def from_config(
     overrides: dict[str, Any] | None = None,
     *,
     date: DATE | None = None,
-    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION = None,
-    environment: ENVIRONMENT = None,
+    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+    environment: ENVIRONMENT | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
-    Run an anemoi inference model from a configuration file
+    Run an anemoi-inference model from a configuration file
 
     Parameters
     ----------
-    config : os.PathLike | dict[str, Any]
+    config : os.PathLike | dict[str, Any] | RunConfiguration
         Path to the configuration file, or dictionary of configuration
     overrides : Optional[dict[str, Any]], optional
         Override for the config, by default None
@@ -162,12 +225,23 @@ def from_config(
     fluent.Action
         earthkit.workflows action of the model results
 
+    Raises
+    -------
+    ImportError
+        Requires `anemoi-inference` installed in the creation environment
+        due to validation of the config.
+
     Examples
     --------
     >>> from earthkit.workflows.plugins.anemoi.fluent import from_config
     >>> from_config("config.yaml", date = "2021-01-01T00:00:00")
     """
-    environment = _crack_environment(environment, ["inference", "initial_conditions"])
+    try:
+        from anemoi.inference.config.run import RunConfiguration
+    except ImportError as e:
+        raise ImportError("Using `from_config` requires `anemoi-inference` to be installed.") from e
+
+    environment = crack_environment(environment, ["inference", "initial_conditions"])
     kwargs.update(overrides or {})
 
     if isinstance(config, os.PathLike):
@@ -180,20 +254,19 @@ def from_config(
         config_dump.update(kwargs)
         configuration = RunConfiguration(**config_dump)
     else:
-        raise TypeError(f"Invalid type for config: {type(config)}. " "Must be os.PathLike, dict, or RunConfiguration.")
+        raise TypeError(
+            f"Invalid type for config: {type(config)}. " "Must be os.PathLike, dict[str, Any], or RunConfiguration."
+        )
 
-    runner = CascadeRunner(configuration)
-    runner.checkpoint.validate_environment(on_difference="warn")
-
-    input_state_source = get_initial_conditions_source(
+    input_state_source = _get_initial_conditions_source(
         config=configuration,
-        date=date or configuration.date,
+        date=date or configuration.date,  # type: ignore
         ensemble_members=ensemble_members,
         payload_metadata={"environment": environment["initial_conditions"]},
     )
 
-    return run_model(
-        runner,
+    return _run_model(
+        metadata,  # TODO Figure out how to get the metadata here
         configuration,
         input_state_source,
         configuration.lead_time,
@@ -207,8 +280,8 @@ def from_input(
     date: DATE,
     lead_time: LEAD_TIME,
     *,
-    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION = None,
-    environment: ENVIRONMENT = None,
+    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+    environment: ENVIRONMENT | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -248,21 +321,18 @@ def from_input(
     >>> from earthkit.workflows.plugins.anemoi.fluent import from_input
     >>> from_input("anemoi_model.ckpt", "mars", date = "2021-01-01T00:00:00", lead_time = "10D")
     """
-    config = RunConfiguration(checkpoint=_parse_checkpoint(ckpt), input=input, **kwargs)
-    environment = _crack_environment(environment, ["inference", "initial_conditions"])
+    config = dict(checkpoint=ckpt, input=input, **kwargs)
+    environment = crack_environment(environment, ["inference", "initial_conditions"])
 
-    runner = CascadeRunner(config)
-    runner.checkpoint.validate_environment(on_difference="warn")
-
-    input_state_source = get_initial_conditions_source(
+    input_state_source = _get_initial_conditions_source(
         config=config,
         date=date,
         ensemble_members=ensemble_members,
         payload_metadata={"environment": environment["initial_conditions"]},
     )
 
-    return run_model(
-        runner,
+    return _run_model(
+        metadata,  # TODO Figure out how to get the metadata here
         config,
         input_state_source,
         lead_time,
@@ -276,8 +346,8 @@ def from_initial_conditions(
     lead_time: LEAD_TIME,
     configuration_kwargs: dict[str, Any] | None = None,
     *,
-    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION = None,
-    environment: list[str] | None = None,
+    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+    environment: ENVIRONMENT | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -322,11 +392,8 @@ def from_initial_conditions(
     >>> from_initial_conditions("anemoi_model.ckpt", init_conditions, lead_time = "10D")
     """
 
-    config = RunConfiguration(checkpoint=_parse_checkpoint(ckpt), **(configuration_kwargs or {}))
-    runner = CascadeRunner(config, **kwargs)
-    environment = _crack_environment(environment, ["inference"])
-
-    runner.checkpoint.validate_environment(on_difference="warn")
+    config = dict(checkpoint=ckpt, **(configuration_kwargs or {}))
+    environment_dict = crack_environment(environment, ["inference"])
 
     if isinstance(initial_conditions, fluent.Action):
         initial_conditions = initial_conditions
@@ -339,26 +406,30 @@ def from_initial_conditions(
         if ensemble_members is None:
             ensemble_members = len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME])
 
-        ensemble_members = _parse_ensemble_members(ensemble_members)
+        parsed_ensemble_members = parse_ensemble_members(ensemble_members)
 
-        if not len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME]) == len(ensemble_members):
+        if not len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME]) == len(parsed_ensemble_members):
             raise ValueError("Number of ensemble members in initial conditions must match `ensemble_members` argument")
         ens_initial_conditions = initial_conditions
 
     else:
         ens_initial_conditions = initial_conditions.transform(
-            _transform_fake,
-            list(zip(_parse_ensemble_members(ensemble_members))),  # type: ignore
-            (ENSEMBLE_DIMENSION_NAME, _parse_ensemble_members(ensemble_members)),  # type: ignore
+            faked_ensemble_transform,
+            list(zip(parse_ensemble_members(ensemble_members))),  # type: ignore
+            (ENSEMBLE_DIMENSION_NAME, parse_ensemble_members(ensemble_members)),  # type: ignore
         )
-    return run_model(
-        runner, config, ens_initial_conditions, lead_time, payload_metadata={"environment": environment["inference"]}
+    return _run_model(
+        metadata,  # TODO Figure out how to get the metadata here
+        config,
+        ens_initial_conditions,
+        lead_time,
+        payload_metadata={"environment": environment_dict["inference"]},
     )
 
 
 def create_dataset(
-    config: dict[str, Any] | os.PathLike,
-    path: os.PathLike,
+    config: dict[str, Any] | os.PathLike | str,
+    path: os.PathLike | str,
     *,
     number_of_tasks: int | None = None,
     overwrite: bool = False,
@@ -366,13 +437,13 @@ def create_dataset(
     environment: list[str] | None = None,
 ) -> fluent.Action:
     """
-    Create an anemoi dataset from a configuration.
+    Create an anemoi-dataset from a configuration.
 
     Parameters
     ----------
-    config : dict[str, Any] | os.PathLike
+    config : dict[str, Any] | os.PathLike | sre
         Configuration to use
-    path : os.PathLike
+    path : os.PathLike | str
         Path to save the dataset to
     number_of_tasks : Optional[int], optional
         Number of tasks to run in parallel, by default None
@@ -393,13 +464,23 @@ def create_dataset(
     fluent.Action
         earthkit.workflows action to create the dataset
 
+    Raises
+    -------
+    ImportError
+        Requires `anemoi-datasets` installed in the creation environment
+        due to validation of the config.
+
     Examples
     --------
     >>> from earthkit.workflows.plugins.anemoi.fluent import create_dataset
     >>> create_dataset("dataset_recipe.yaml", "output_dir/dataset.zarr")
     """
     import yaml
-    from anemoi.datasets.create import creator_factory
+
+    try:
+        from anemoi.datasets.create import creator_factory
+    except ImportError as e:
+        raise ImportError("Using `create_dataset` requires `anemoi-datasets` to be installed.") from e
 
     config_path, config_dict = None, None
 
@@ -415,7 +496,6 @@ def create_dataset(
         config_dict = yaml.safe_load(open(config_path))
 
     if number_of_tasks is None:
-
         from anemoi.datasets.create.config import loader_config
         from anemoi.datasets.dates.groups import Groups
 
@@ -493,10 +573,10 @@ def from_dataset(
     date: DATE,
     lead_time: LEAD_TIME,
     *,
-    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION = None,
+    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
     input_template: dict[str, Any] | None = None,
     number_of_dataset_tasks: int | None = None,
-    environment: ENVIRONMENT = None,
+    environment: ENVIRONMENT | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -552,7 +632,7 @@ def from_dataset(
     if not isinstance(dataset_config, os.PathLike):
         dataset_config = yaml.safe_load(open(dataset_config))
 
-    checkpoint = Checkpoint(_parse_checkpoint(ckpt))
+    checkpoint = Checkpoint(ckpt)
 
     dates = list(map(lambda x: to_datetime(date) + x, checkpoint.lagged))
     end_date = max(dates)
@@ -568,16 +648,14 @@ def from_dataset(
     temp_config_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False)
     yaml.dump(dataset_config, open(temp_config_file.name, "w"))
 
-    runner_config = RunConfiguration(checkpoint=_parse_checkpoint(ckpt), input="dummy", **kwargs)
-    runner = CascadeRunner(runner_config)
-    runner.checkpoint.validate_environment(on_difference="warn")
+    runner_config = dict(checkpoint=ckpt, input="dummy", **kwargs)
 
-    environment = _crack_environment(environment, ["inference", "dataset", "initial_conditions"])
+    environment = crack_environment(environment, ["inference", "dataset", "initial_conditions"])
 
     def construct_configuration(dataset_location: str):
         """Create configuration from dataset location"""
 
-        def insert_dataset_path(template: dict[str, Any] | list[str] | str) -> dict[str, Any] | list[str] | str:
+        def insert_dataset_path(template: dict[str, Any] | list[str] | str) -> dict | list | str:
             """Insert the dataset path into the template"""
             if isinstance(template, dict):
                 return {k: insert_dataset_path(v) for k, v in template.items()}
@@ -592,8 +670,8 @@ def from_dataset(
 
         dataset_input = insert_dataset_path(input_template or {"dataset": "%DATASET_PATH%"})
 
-        config = RunConfiguration(
-            checkpoint=_parse_checkpoint(ckpt),
+        config = dict(
+            checkpoint=ckpt,
             input=dataset_input,
             **kwargs,
         )
@@ -610,25 +688,30 @@ def from_dataset(
         fluent.Payload(construct_configuration, args=(fluent.Node.input_name(0),))
     )
 
-    input_state_source = get_initial_conditions_source(
+    input_state_source = _get_initial_conditions_source(
         config=init_conditions_config,
         date=date,
         ensemble_members=ensemble_members,
         payload_metadata={"environment": environment["initial_conditions"]},
     )
-    return run_model(
-        runner, runner_config, input_state_source, lead_time, payload_metadata={"environment": environment["inference"]}
+    return _run_model(
+        metadata,  # TODO Figure out how to get the metadata here
+        runner_config,
+        input_state_source,
+        lead_time,
+        payload_metadata={"environment": environment["inference"]},
     )
 
 
 class Action(fluent.Action):
+    """Anemoi Fluent Action"""
 
     def infer(
         self,
         ckpt: VALID_CKPT,
         lead_time: LEAD_TIME,
         configuration_kwargs: dict[str, Any] | None = None,
-        environment: list[str] = None,
+        environment: ENVIRONMENT | None = None,
         **kwargs,
     ) -> fluent.Action:
         """

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from anemoi.utils.dates import as_timedelta
 from earthkit.data.utils.dates import to_datetime
+from earthkit.workflows.fluent import capture_payload_metadata
 
 from earthkit.workflows import fluent
 
@@ -246,6 +247,7 @@ class Inference:
             **kwargs,
         )
 
+    @capture_payload_metadata
     def from_input(
         self,
         input: str | dict[str, Any],
@@ -299,6 +301,7 @@ class Inference:
             payload_metadata={"environment": environment_dict["inference"]},
         )
 
+    @capture_payload_metadata
     def from_initial_conditions(
         self,
         initial_conditions: State | None | fluent.Action | fluent.Payload | Callable,
@@ -376,6 +379,7 @@ class Inference:
         )
 
 
+@capture_payload_metadata
 def from_config(
     config: os.PathLike | dict[str, Any] | RunConfiguration,
     overrides: dict[str, Any] | None = None,
@@ -462,6 +466,7 @@ def from_config(
     )
 
 
+@capture_payload_metadata
 def from_input(
     ckpt: VALID_CKPT,
     input: str | dict[str, Any],
@@ -519,6 +524,7 @@ def from_input(
     )
 
 
+@capture_payload_metadata
 def from_initial_conditions(
     ckpt: VALID_CKPT,
     initial_conditions: State | None | fluent.Action | fluent.Payload | Callable,
@@ -717,6 +723,7 @@ def create_dataset(
     return verify.map(get_path)
 
 
+@capture_payload_metadata
 def from_dataset(
     ckpt: VALID_CKPT,
     dataset_config: dict[str, Any] | os.PathLike,

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -193,6 +193,189 @@ def _run_model(
     return model_results.expand_as_qube(qube.remove_by_key("step"))
 
 
+class Inference:
+    """Build fluent workflow actions for one anemoi inference setup."""
+
+    def __init__(
+        self,
+        ckpt: VALID_CKPT,
+        lead_time: LEAD_TIME,
+        *,
+        environment: ENVIRONMENT | None = None,
+        metadata: Metadata | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        ckpt : VALID_CKPT
+            Checkpoint to load
+        lead_time : LEAD_TIME
+            Lead time to run out to. Can be a string,
+            i.e. `1H`, `1D`, int, or a datetime.timedelta
+        environment : ENVIRONMENT, optional
+            Environment to run the model in, by default None
+        metadata : Optional[Metadata], optional
+            `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+        """
+        self.ckpt = ckpt
+        self.lead_time = lead_time
+        self.environment: ENVIRONMENT = environment if environment is not None else []
+        self.metadata: Metadata = _get_metadata(ckpt, metadata=metadata)
+        self.kwargs: dict[str, Any] = kwargs
+
+    def _config(self, **kwargs: Any) -> dict[str, Any]:
+        return {"checkpoint": self.ckpt, **self.kwargs, **kwargs}
+
+    def _run_model(
+        self,
+        config: RunConfiguration | dict,
+        input_state_source: fluent.Action,
+        *,
+        payload_metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> fluent.Action:
+        return _run_model(
+            self.metadata,
+            config,
+            input_state_source,
+            self.lead_time,
+            payload_metadata=payload_metadata,
+            **kwargs,
+        )
+
+    def from_input(
+        self,
+        input: str | dict[str, Any],
+        date: DATE,
+        *,
+        ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+        **kwargs: Any,
+    ) -> fluent.Action:
+        """
+        Run an anemoi inference model from a given input source.
+
+        Parameters
+        ----------
+        input : str | dict[str, Any]
+            `anemoi.inference` input source.
+            Can be `mars`, `grib`, etc or a dictionary of input configuration,
+        date : DATE
+            Date to get initial conditions for
+        ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
+            Number of ensemble members to run, None will run a single instance, by default None
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+
+        Returns
+        -------
+        fluent.Action
+            earthkit.workflows action of the model results
+
+        Examples
+        -------
+        >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
+        >>> inference = Inference("anemoi_model.ckpt", lead_time = "10D")
+        >>> inference.from_input("mars", date = "2021-01-01T00:00:00")
+        """
+        config = self._config(input=input, **kwargs)
+        environment_dict = crack_environment(
+            self.environment,
+            ["inference", "initial_conditions"],
+        )
+
+        input_state_source = _get_initial_conditions_source(
+            config=config,
+            date=date,
+            ensemble_members=ensemble_members,
+            payload_metadata={"environment": environment_dict["initial_conditions"]},
+        )
+
+        return self._run_model(
+            config,
+            input_state_source,
+            payload_metadata={"environment": environment_dict["inference"]},
+        )
+
+    def from_initial_conditions(
+        self,
+        initial_conditions: State | None | fluent.Action | fluent.Payload | Callable,
+        *,
+        ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+        **kwargs: Any,
+    ) -> fluent.Action:
+        """
+        Run an anemoi inference model from initial conditions.
+
+        Parameters
+        ----------
+        initial_conditions : State | None | fluent.Action | fluent.Payload | Callable
+            Initial conditions for the model
+            Can be other fluent actions, payloads, a callable, a State, or None.
+            None creates a source node that yields None.
+            If a fluent action and multiple ensemble member initial conditions
+            are included, the dimension must be named `ensemble_member`.
+        ensemble_members : Optional[ENSEMBLE_MEMBER_SPECIFICATION], optional
+            Number of ensemble members to run.
+            If initial_conditions is a fluent action with multiple ensemble
+            members, this argument can be set to None, and the number of
+            ensemble members will be inferred from the action.
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+
+        Returns
+        -------
+        fluent.Action
+            earthkit.workflows action of the model results
+
+        Examples
+        --------
+        >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
+        >>> inference = Inference("anemoi_model.ckpt", lead_time = "10D")
+        >>> inference.from_initial_conditions(init_conditions)
+        """
+        config = self._config(**kwargs)
+        environment_dict = crack_environment(self.environment, ["inference"])
+
+        if isinstance(initial_conditions, fluent.Action):
+            initial_conditions_source = initial_conditions
+        elif isinstance(initial_conditions, (Callable, fluent.Payload)):
+            initial_conditions_source = fluent.from_source([initial_conditions])  # type: ignore
+        else:
+            initial_conditions_source = fluent.from_source(
+                [fluent.Payload(lambda: initial_conditions)],
+                dims=["date"],
+            )  # type: ignore
+
+        if ENSEMBLE_DIMENSION_NAME in initial_conditions_source.nodes.dims:
+            if ensemble_members is None:
+                ensemble_members = len(initial_conditions_source.nodes.coords[ENSEMBLE_DIMENSION_NAME])
+
+            parsed_ensemble_members = parse_ensemble_members(ensemble_members)
+
+            if len(initial_conditions_source.nodes.coords[ENSEMBLE_DIMENSION_NAME]) != len(parsed_ensemble_members):
+                raise ValueError(
+                    "Number of ensemble members in initial conditions must match `ensemble_members` argument"
+                )
+            ens_initial_conditions = initial_conditions_source
+
+        else:
+            parsed_ensemble_members = parse_ensemble_members(ensemble_members)
+            ens_initial_conditions = initial_conditions_source.transform(
+                faked_ensemble_transform,
+                list(zip(parsed_ensemble_members)),  # type: ignore
+                (ENSEMBLE_DIMENSION_NAME, parsed_ensemble_members),  # type: ignore
+            )
+
+        return self._run_model(
+            config,
+            ens_initial_conditions,
+            payload_metadata={"environment": environment_dict["inference"]},
+        )
+
+
 def from_config(
     config: os.PathLike | dict[str, Any] | RunConfiguration,
     overrides: dict[str, Any] | None = None,
@@ -329,28 +512,16 @@ def from_input(
     >>> from earthkit.workflows.plugins.anemoi.fluent import from_input
     >>> from_input("anemoi_model.ckpt", "mars", date = "2021-01-01T00:00:00", lead_time = "10D")
     """
-    config = dict(checkpoint=ckpt, input=input, **kwargs)
-    environment = crack_environment(environment, ["inference", "initial_conditions"])
-
-    input_state_source = _get_initial_conditions_source(
-        config=config,
-        date=date,
+    return Inference(ckpt, lead_time, environment=environment, metadata=metadata, **kwargs).from_input(
+        input,
+        date,
         ensemble_members=ensemble_members,
-        payload_metadata={"environment": environment["initial_conditions"]},
-    )
-
-    return _run_model(
-        _get_metadata(ckpt, metadata=metadata),
-        config,
-        input_state_source,
-        lead_time,
-        payload_metadata={"environment": environment["inference"]},
     )
 
 
 def from_initial_conditions(
     ckpt: VALID_CKPT,
-    initial_conditions: State | fluent.Action | fluent.Payload | Callable,
+    initial_conditions: State | None | fluent.Action | fluent.Payload | Callable,
     lead_time: LEAD_TIME,
     *,
     ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
@@ -365,9 +536,10 @@ def from_initial_conditions(
     ----------
     ckpt : VALID_CKPT
         Checkpoint to load
-    initial_conditions : State | fluent.Action | fluent.Payload | Callable
+    initial_conditions : State | None | fluent.Action | fluent.Payload | Callable
         Initial conditions for the model
-        Can be other fluent actions, payloads, or a callable, or a State.
+        Can be other fluent actions, payloads, a callable, a State, or None.
+        None creates a source node that yields None.
         If a fluent action and multiple ensemble member initial conditions
         are included, the dimension must be named `ensemble_member`.
     lead_time : LEAD_TIME
@@ -399,39 +571,9 @@ def from_initial_conditions(
     >>> from earthkit.workflows.plugins.anemoi.fluent import from_initial_conditions
     >>> from_initial_conditions("anemoi_model.ckpt", init_conditions, lead_time = "10D")
     """
-
-    config = dict(checkpoint=ckpt, **kwargs)
-    environment_dict = crack_environment(environment, ["inference"])
-
-    if isinstance(initial_conditions, fluent.Action):
-        initial_conditions = initial_conditions
-    elif isinstance(initial_conditions, (Callable, fluent.Payload)):
-        initial_conditions = fluent.from_source([initial_conditions])  # type: ignore
-    else:
-        initial_conditions = fluent.from_source([fluent.Payload(lambda: initial_conditions)], dims=["date"])  # type: ignore
-
-    if ENSEMBLE_DIMENSION_NAME in initial_conditions.nodes.dims:
-        if ensemble_members is None:
-            ensemble_members = len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME])
-
-        parsed_ensemble_members = parse_ensemble_members(ensemble_members)
-
-        if not len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME]) == len(parsed_ensemble_members):
-            raise ValueError("Number of ensemble members in initial conditions must match `ensemble_members` argument")
-        ens_initial_conditions = initial_conditions
-
-    else:
-        ens_initial_conditions = initial_conditions.transform(
-            faked_ensemble_transform,
-            list(zip(parse_ensemble_members(ensemble_members))),  # type: ignore
-            (ENSEMBLE_DIMENSION_NAME, parse_ensemble_members(ensemble_members)),  # type: ignore
-        )
-    return _run_model(
-        _get_metadata(ckpt, metadata=metadata),
-        config,
-        ens_initial_conditions,
-        lead_time,
-        payload_metadata={"environment": environment_dict["inference"]},
+    return Inference(ckpt, lead_time, environment=environment, metadata=metadata, **kwargs).from_initial_conditions(
+        initial_conditions,
+        ensemble_members=ensemble_members,
     )
 
 
@@ -775,6 +917,7 @@ fluent.Action.register("anemoi", Action)
 
 
 __all__ = [
+    "Inference",
     "from_config",
     "from_input",
     "from_initial_conditions",

--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -14,32 +14,28 @@ import functools
 import logging
 from collections.abc import Generator
 from io import BytesIO
-from typing import TYPE_CHECKING
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import earthkit.data as ekd
 from anemoi.inference.config.run import RunConfiguration
 from anemoi.inference.types import State
 from anemoi.utils.dates import frequency_to_seconds
-from anemoi.utils.dates import frequency_to_timedelta as to_timedelta
 from anemoi.utils.grib import shortname_to_paramid
 from earthkit.data.utils.dates import to_datetime
 
-from earthkit.workflows import fluent
 from earthkit.workflows import mark
-from earthkit.workflows.plugins.anemoi.runner import CascadeRunner
-from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
-from earthkit.workflows.plugins.anemoi.utils import expansion_qube
+
+from .runner import CascadeRunner
 
 if TYPE_CHECKING:
     from anemoi.inference.input import Input
     from anemoi.transform.variables import Variable
 
-    from earthkit.workflows.plugins.anemoi.types import DATE
-    from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_MEMBER_SPECIFICATION
-    from earthkit.workflows.plugins.anemoi.types import LEAD_TIME
+    from .types import DATE, LEAD_TIME
 
 LOG = logging.getLogger(__name__)
+
+raise Exception()
 
 
 def _get_initial_conditions(input: Input, date: DATE) -> State:
@@ -75,173 +71,6 @@ def _get_initial_conditions_from_config(config: RunConfiguration, date: DATE, en
     state = _get_initial_conditions(input, date)
     state.pop("_grib_templates_for_output", None)
     return state
-
-
-def _transform_fake(act: fluent.Action, ens_num: int | None = None) -> fluent.Action:
-    """Transform the action to simulate ensemble members"""
-
-    def _empty_payload(x, ens_mem: int | None):
-        assert isinstance(x, dict), "Input state must be a dictionary"
-        if ens_mem is not None:
-            x["ensemble_member"] = ens_mem
-        return x
-
-    return act.map(fluent.Payload(_empty_payload, [fluent.Node.input_name(0), ens_num]))
-
-
-def _parse_ensemble_members(ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION) -> list[int] | list[None]:
-    """Parse ensemble members"""
-    if ensemble_members is None:
-        return [None]
-    if isinstance(ensemble_members, int):
-        if ensemble_members < 1:
-            raise ValueError("Number of ensemble members must be greater than 0.")
-        return list(range(1, ensemble_members + 1))
-    return list(ensemble_members)
-
-
-def get_initial_conditions_source(
-    config: RunConfiguration | fluent.Action,
-    date: DATE,
-    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION = None,
-    *,
-    initial_condition_perturbation: bool = False,
-    payload_metadata: dict[str, Any] | None = None,
-) -> fluent.Action:
-    """
-    Get the initial conditions for the model
-
-    Parameters
-    ----------
-    config : RunConfiguration | fluent.Action
-        Configuration object, must contain checkpoint and input.
-        If is a fluent action, the action must return the RunConfiguration object.
-    date : str | tuple[int, int, int]
-        Date to get initial conditions for
-    ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
-        Number of ensemble members to get, by default None
-    initial_condition_perturbation : bool, optional
-        Whether to get perturbed initial conditions, by default False
-        If False, only one initial condition is returned, and
-        the ensemble members are simulated by wrapping the action.
-    payload_metadata : Optional[dict[str, Any]], optional
-        Metadata to add to the payload, by default None
-
-    Returns
-    -------
-    fluent.Action
-        Fluent action of the initial conditions
-    """
-    ens_members = _parse_ensemble_members(ensemble_members)
-    if initial_condition_perturbation:
-        if any(ens is None for ens in ens_members):
-            raise ValueError("Ensemble members must be specified when using initial condition perturbation.")
-        if isinstance(config, fluent.Action):
-            init_conditions = config.transform(
-                lambda x, *a: x.map(
-                    fluent.Payload(
-                        _get_initial_conditions_from_config,
-                        args=(fluent.Node.input_name(0)),
-                        kwargs=dict(ens_num=a[0], date=date),
-                        metadata=payload_metadata,
-                    )
-                ),
-                params=ens_members,
-                dim=(ENSEMBLE_DIMENSION_NAME, ens_members),
-            )
-            init_conditions._add_dimension("date", [to_datetime(date)])
-            return init_conditions
-
-        return fluent.from_source(
-            [
-                [
-                    # fluent.Payload(_get_initial_conditions_ens, kwargs=dict(input=input, date=date, ens_mem=ens_mem))
-                    fluent.Payload(
-                        _get_initial_conditions_from_config,
-                        kwargs=dict(config=config, date=date, ens_mem=ens_mem),
-                        metadata=payload_metadata,
-                    )
-                    for ens_mem in ens_members
-                ],
-            ],  # type: ignore
-            coords={"date": [to_datetime(date)], ENSEMBLE_DIMENSION_NAME: ens_members},
-        )
-
-    if isinstance(config, fluent.Action):
-        init_condition = fluent.Payload(
-            _get_initial_conditions_from_config,
-            args=(fluent.Node.input_name(0),),
-            kwargs=dict(date=date),
-            metadata=payload_metadata,
-        )
-        single_init = config.map(init_condition)
-        single_init._add_dimension("date", [to_datetime(date)])
-    else:
-        init_condition = fluent.Payload(
-            _get_initial_conditions_from_config, kwargs=dict(config=config, date=date), metadata=payload_metadata
-        )
-        single_init = fluent.from_source(
-            [
-                init_condition,
-            ],  # type: ignore
-            coords={"date": [to_datetime(date)]},
-        )
-
-    # Wrap with empty payload to simulate ensemble members
-    expanded_init = single_init.transform(
-        _transform_fake,
-        list(zip(ens_members)),
-        (ENSEMBLE_DIMENSION_NAME, ens_members),  # type: ignore
-    )
-    if ENSEMBLE_DIMENSION_NAME not in expanded_init.nodes.coords:
-        expanded_init.nodes = expanded_init.nodes.expand_dims(ENSEMBLE_DIMENSION_NAME)
-    return expanded_init
-
-
-def run_model(
-    runner: CascadeRunner,
-    config: RunConfiguration,
-    input_state_source: fluent.Action,
-    lead_time: LEAD_TIME,
-    payload_metadata: dict[str, Any] | None = None,
-    **kwargs,
-) -> fluent.Action:
-    """
-    Run the model, expanding the results to the correct dimensions.
-
-    Parameters
-    ----------
-    runner : Runner
-        `anemoi.inference` runner
-    config : RunConfiguration
-        Configuration object
-    input_state_source : fluent.Action
-        Fluent action of initial conditions
-    lead_time : LEAD_TIME
-        Lead time to run out to. Can be a string,
-        i.e. `1H`, `1D`, int, or a datetime.timedelta
-    payload_metadata : Optional[dict[str, Any]], optional
-        Metadata to add to the payload, by default None
-    kwargs : dict
-        Additional arguments to pass to the runner
-
-    Returns
-    -------
-    fluent.Action
-        Cascade action of the model results
-    """
-    lead_time = to_timedelta(lead_time)
-
-    model_payload = fluent.Payload(
-        run_as_earthkit_from_config,
-        args=(fluent.Node.input_name(0),),
-        kwargs=dict(config=config, lead_time=lead_time, **kwargs),
-        metadata=payload_metadata,
-    )
-
-    qube = expansion_qube(runner.checkpoint._metadata, lead_time)
-    model_results = input_state_source.map(model_payload, yields=("step", list(qube.axes()["step"])))
-    return model_results.expand_as_qube(qube.remove_by_key("step"))
 
 
 def run(input_state: dict, runner: CascadeRunner, lead_time: LEAD_TIME) -> Generator[Any]:

--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
 
 LOG = logging.getLogger(__name__)
 
-raise Exception()
-
 
 def _get_initial_conditions(input: Input, date: DATE) -> State:
     """Get initial conditions for the model"""
@@ -61,7 +59,7 @@ def _get_initial_conditions_ens(input: Input, ens_mem: int, date: DATE) -> State
 
 def _get_initial_conditions_from_config(config: RunConfiguration, date: DATE, ens_mem: int | None = None) -> State:
     """Get initial conditions for the model"""
-
+    # TODO: Instantiate the input directly
     runner = CascadeRunner(config)
     input = runner.create_input()
 

--- a/src/earthkit/workflows/plugins/anemoi/runner.py
+++ b/src/earthkit/workflows/plugins/anemoi/runner.py
@@ -19,12 +19,11 @@ import logging
 import os
 
 from anemoi.inference.config.run import RunConfiguration
-from anemoi.inference.forcings import ComputedForcings
-from anemoi.inference.forcings import CoupledForcings
-from anemoi.inference.forcings import Forcings
+from anemoi.inference.forcings import ComputedForcings, CoupledForcings, Forcings
 from anemoi.inference.inputs import create_input
 from anemoi.inference.inputs.ekd import EkdInput
 from anemoi.inference.post_processors import create_post_processor
+from anemoi.inference.pre_processors import create_pre_processor
 from anemoi.inference.processor import Processor
 from anemoi.inference.runner import Runner
 from anemoi.inference.types import IntArray
@@ -64,25 +63,8 @@ class CascadeRunner(Runner):
             The created input.
         """
         input = create_input(
-            self, self.config.input, variables=self.checkpoint.select_variables(include=["prognostic", "forcing"])
+            self, self.config.input, variables=self.checkpoint.select_variables(include=["prognostic", "forcing"])  # type: ignore # Error in anemoi.inference
         )
-
-        def set_variables(input: EkdInput) -> EkdInput:
-            """Set the variables for the input."""
-            if not isinstance(input, EkdInput):
-                LOG.warning("Input is not an instance of EkdInput, setting the expected variables may not work.")
-            return input
-
-        from anemoi.inference.inputs.cutout import Cutout
-
-        if isinstance(input, Cutout):  # type: ignore
-            input.sources = {src: set_variables(src_input) for src, src_input in input.sources.items()}
-        elif isinstance(input, EkdInput):
-            input = set_variables(input)
-        # If input is not an instance of EkdInput, we cannot set the variables
-        # but we can still use the input as it is.
-        # This is a fallback for when the input is not an instance of EkdInput.
-        LOG.debug("Input: %s", input)
         return input
 
     def create_constant_computed_forcings(self, variables: list[str], mask: IntArray) -> list[Forcings]:
@@ -142,9 +124,8 @@ class CascadeRunner(Runner):
         # there are supposed to be already in the state dictionary
         # or managed by the user.
         input = create_input(
-            self, self.config.input, variables=self.checkpoint.select_variables(include=["constant", "forcing"])
+            self, self.config.input, variables=self.checkpoint.select_variables(include=["constant", "forcing"])  # type: ignore # Error in anemoi.inference
         )
-        # return []
         result = CoupledForcings(self, input, variables, mask)
         LOG.debug("Constant coupled forcing: %s", result)
         return [result]
@@ -170,6 +151,19 @@ class CascadeRunner(Runner):
         LOG.warning("Coupled forcings are not supported by this runner: %s", variables)
         return []
 
+    def create_pre_processors(self) -> list[Processor]:
+        """Create pre-processors.
+
+        Returns
+        -------
+        List[Processor]
+            The created pre-processors.
+        """
+        result = []
+        for processor in self.config.pre_processors:
+            result.append(create_pre_processor(self, processor))
+        return result
+
     def create_post_processors(self) -> list[Processor]:
         """Create post-processors.
 
@@ -181,6 +175,4 @@ class CascadeRunner(Runner):
         result = []
         for processor in self.config.post_processors:
             result.append(create_post_processor(self, processor))
-
-        LOG.debug("Post processors: %s", result)
         return result

--- a/src/earthkit/workflows/plugins/anemoi/types.py
+++ b/src/earthkit/workflows/plugins/anemoi/types.py
@@ -9,15 +9,13 @@
 
 import datetime
 import os
-from collections.abc import Sequence
-from typing import Any
-from typing import Optional
-from typing import Union
+from collections.abc import Mapping, Sequence
+from typing import Any, Union
 
-VALID_CKPT = Union[os.PathLike, str, dict[str, Any]]
+VALID_CKPT = Union[os.PathLike[str], str, Mapping[str, Any]]
 LEAD_TIME = Union[int, str, datetime.timedelta]
 DATE = Union[datetime.datetime, tuple[int, int, int], str]
-ENVIRONMENT = Optional[Union[dict[str, list[str]], list[str]]]
+ENVIRONMENT = Union[Mapping[str, list[str]], list[str]]
 
-ENSEMBLE_MEMBER_SPECIFICATION = Union[int, Sequence[int], None]
+ENSEMBLE_MEMBER_SPECIFICATION = Union[int, Sequence[int]]
 ENSEMBLE_DIMENSION_NAME: str = "ensemble_member"

--- a/src/earthkit/workflows/plugins/anemoi/utils.py
+++ b/src/earthkit/workflows/plugins/anemoi/utils.py
@@ -11,16 +11,21 @@
 import functools
 import operator
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from anemoi.utils.dates import frequency_to_seconds
 from qubed import Qube
 
+from earthkit.workflows import fluent
+
+from .types import ENVIRONMENT
+
 if TYPE_CHECKING:
     from anemoi.inference.metadata import Metadata
 
-    from earthkit.workflows.plugins.anemoi.types import LEAD_TIME
+    from .types import ENSEMBLE_MEMBER_SPECIFICATION, ENVIRONMENT, LEAD_TIME
+
+E = TypeVar("E", bound=ENVIRONMENT)
 
 
 def expansion_qube(metadata: "Metadata", lead_time: "LEAD_TIME") -> Qube:
@@ -82,12 +87,16 @@ def expansion_qube(metadata: "Metadata", lead_time: "LEAD_TIME") -> Qube:
     """
     variables = metadata.select_variables(include=["diagnostic", "prognostic"], has_mars_requests=False)
     variables_metadata = metadata.typed_variables
+    model_step = metadata.timestep.seconds
+    return _expansion_qube(variables, variables_metadata, model_step, lead_time)
 
+
+def _expansion_qube(variables: list[str], variables_metadata: dict, model_step: int, lead_time: "LEAD_TIME") -> Qube:
+    """Create a Qube object from elements from model metadata and lead time."""
     surface_variables = {variables_metadata[var] for var in variables if variables_metadata[var].is_surface_level}
     pressure_variables = {variables_metadata[var] for var in variables if variables_metadata[var].is_pressure_level}
     model_variables = {variables_metadata[var] for var in variables if variables_metadata[var].is_model_level}
 
-    model_step = metadata.timestep.seconds
     lead_time_seconds = frequency_to_seconds(lead_time)
     steps = list(map(lambda x: x // 3600, range(model_step, lead_time_seconds + model_step, model_step)))
 
@@ -139,3 +148,85 @@ def expansion_qube(metadata: "Metadata", lead_time: "LEAD_TIME") -> Qube:
     )
 
     return pressure_qube | model_qube | surface_qube
+
+
+def parse_ensemble_members(ensemble_members: "ENSEMBLE_MEMBER_SPECIFICATION | None") -> list[int] | list[None]:
+    """Parse ensemble members"""
+    if ensemble_members is None:
+        return [None]
+    if isinstance(ensemble_members, int):
+        if ensemble_members < 1:
+            raise ValueError("Number of ensemble members must be greater than 0.")
+        return list(range(1, ensemble_members + 1))
+    return list(ensemble_members)
+
+
+def faked_ensemble_transform(act: fluent.Action, ens_num: int | None = None) -> fluent.Action:
+    """Transform the action to simulate ensemble members"""
+
+    def _empty_payload(x, ens_mem: int | None):
+        assert isinstance(x, dict), "Input state must be a dictionary"
+        if ens_mem is not None:
+            x["ensemble_member"] = ens_mem
+        return x
+
+    return act.map(fluent.Payload(_empty_payload, [fluent.Node.input_name(0), ens_num]))
+
+
+def _add_self_to_environment(environment: E) -> E:
+    """
+    Add earthkit-workflows-anemoi to the environment list.
+
+    Parameters
+    ----------
+    environment : list[str] | dict[str, list[str]]
+        Environment list to self in place to
+
+    Returns
+    -------
+    list[str] | dict[str, list[str]]
+        Environment list with self added
+    """
+    from . import __version__ as version
+
+    if version.split(".")[-1].startswith("dev"):
+        # If the version is a development version, ignore it
+        # such that it is not overwritten
+        # e.g. "0.3.1.dev0" -> "0.3"
+        return environment
+
+    version = ".".join(version.split(".")[:3])  # Ensure version is in x.y.z format
+
+    package_name = "earthkit-workflows-anemoi"
+    self_var = f"{package_name}~={version}"
+
+    def add_self_to_list(env_list: list[str]) -> list[str]:
+        if len(env_list) == 0:
+            # If the environment is empty, leave it as such
+            return []
+
+        if any(str(e).startswith(package_name) for e in env_list):
+            # If the environment already contains the self variable, return it as is
+            return env_list
+
+        env_list.append(self_var)
+        return env_list
+
+    if isinstance(environment, list):
+        environment = add_self_to_list(environment)
+    elif isinstance(environment, dict):
+        for key in environment:
+            environment[key] = add_self_to_list(environment[key])
+    return environment
+
+
+def crack_environment(environment: ENVIRONMENT | None, keys: list[str]) -> dict[str, list[str]]:
+    """Crack the environment into a dictionary of lists."""
+    if environment is None:
+        return _add_self_to_environment({k: [] for k in keys})
+    elif isinstance(environment, list):
+        return _add_self_to_environment({k: environment for k in keys})
+    elif isinstance(environment, dict):
+        return _add_self_to_environment({k: environment.get(k, []) for k in keys})
+    else:
+        raise TypeError(f"Invalid type for environment: {type(environment)}. Must be list or dict.")

--- a/src/earthkit/workflows/plugins/anemoi/utils.py
+++ b/src/earthkit/workflows/plugins/anemoi/utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 E = TypeVar("E", bound=ENVIRONMENT)
 
 
-def expansion_qube(metadata: "Metadata", lead_time: "LEAD_TIME") -> Qube:
+def expansion_qube_from_metadata(metadata: "Metadata", lead_time: "LEAD_TIME") -> Qube:
     """Create a Qube object from model metadata and lead time.
 
     This function constructs a Qube object by analysing the model's metadata
@@ -88,6 +88,70 @@ def expansion_qube(metadata: "Metadata", lead_time: "LEAD_TIME") -> Qube:
     variables = metadata.select_variables(include=["diagnostic", "prognostic"], has_mars_requests=False)
     variables_metadata = metadata.typed_variables
     model_step = metadata.timestep.seconds
+    return _expansion_qube(variables, variables_metadata, model_step, lead_time)
+
+
+def expansion_qube_from_variables(
+    variables: list[str], variables_metadata: dict, model_step: int, lead_time: "LEAD_TIME"
+) -> Qube:
+    """Create a Qube object from a list of variable names, their metadata, model step, and lead time.
+
+    This function constructs a Qube object by analysing the provided list of variable names
+    and their corresponding metadata to identify surface, pressure level, and model level variables.
+    It creates a hierarchical qube structure organising variables by their vertical coordinate
+    type and expands them across time steps.
+
+    Parameters
+    ----------
+    variables : list[str]
+        A list of variable names to include in the qube. These should correspond to keys in the
+        variables_metadata dictionary.
+    variables_metadata : dict
+        A dictionary mapping variable names to their metadata objects. Each metadata object should
+        contain information about whether the variable is a surface level, pressure level, or model level variable,
+        as well as its parameter and level information.
+    model_step : int
+        The model's time step in seconds. This is used to calculate the time steps for expansion.
+    lead_time : LEAD_TIME
+        The forecast lead time as an integer or string (e.g., "7D" for 7 days). This determines the number of time steps in the expansion.
+        If an integer is provided, it is interpreted as hours.
+
+    Returns
+    -------
+    Qube
+        A qube object with a hierarchical structure containing up to three branches: surface, pressure, and model level variables. Each branch contains the appropriate parameters and coordinates.
+
+    Notes
+    -----
+    The function creates a qube with the following structure:
+
+    - Surface variables: expanded over (step, param)
+    - Pressure level variables: expanded over (step, param, level)
+    - Model level variables: expanded over (step, param, level)
+
+    Only variables that are present in the provided list and have corresponding metadata are included. The time steps are calculated from the model's time step size up to the specified lead time.
+
+    Examples
+    --------
+    Create expansion coordinates for specific variables:
+
+    >>> variables = ["2t", "msl", "10u"]
+    >>> variables_metadata = {
+            "2t": ...,
+            "msl": ...,
+            "10u": ...,
+        }
+    >>> model_step = 3600  # 1 hour in seconds
+    >>> lead_time = "5D"
+    >>> qube = expansion_qube_from_variables(variables, variables_metadata, model_step, lead_time)
+    >>> qube.axes()
+    {'step': {6, 12, 18, ..., 120}, 'param': {130, 134, 165}, 'level': {500, 1000}}
+
+    See Also
+    --------
+    Qube : The Qube class for manual qube construction
+    expansion_qube_from_metadata : Create a Qube object directly from model metadata.
+    """
     return _expansion_qube(variables, variables_metadata, model_step, lead_time)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from pathlib import Path
+
+import pytest
+from anemoi.inference.testing import fake_checkpoints
+from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
+
+
+@pytest.fixture
+@fake_checkpoints
+def mock_config(tmp_path: Path):
+    import yaml
+
+    parent_dir = Path(__file__).parent
+    config_path = parent_dir / "configs" / "simple.yaml"
+
+    config_dict = yaml.safe_load(config_path.read_text())
+    config_dict["checkpoint"] = f"{parent_dir}/{config_dict['checkpoint']}"
+
+    with open(tmp_path / "simple.yaml", "w") as f:
+        yaml.safe_dump(config_dict, f)
+
+    tmp_path = tmp_path / "simple.yaml"
+
+    return MockRunConfiguration.load(
+        str((tmp_path).absolute()),
+        overrides=dict(runner="testing", device="cpu", input="dummy"),
+    )

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -14,25 +14,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 from anemoi.inference.testing import fake_checkpoints
-from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
-from xarray import DataArray
-from xarray import DataTree
+from xarray import DataArray, DataTree
 
-from earthkit.workflows.plugins.anemoi.fluent import Action
-from earthkit.workflows.plugins.anemoi.fluent import from_config
-from earthkit.workflows.plugins.anemoi.fluent import from_initial_conditions
-from earthkit.workflows.plugins.anemoi.fluent import from_input
+from earthkit.workflows.plugins.anemoi.fluent import Action, from_config, from_initial_conditions, from_input
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
-
-
-@pytest.fixture
-@fake_checkpoints
-def mock_config():
-    return MockRunConfiguration.load(
-        (Path(__file__).parent / "configs/simple.yaml").absolute(),
-        overrides=dict(runner="testing", device="cpu"),
-    )
-
 
 STANDARD_INFERENCE_TESTS = [
     # Test inputs of ensembles
@@ -131,6 +116,28 @@ def test_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape
     kwargs.pop("date", None)
 
     action = from_initial_conditions(ckpt_full_path, None, ensemble_members=ensemble_members, **kwargs)
+    shape.pop("date", None)
+    assert_shape(action, shape)
+
+
+@pytest.mark.parametrize(
+    "ckpt, ensemble_members, kwargs, shape",
+    STANDARD_INFERENCE_TESTS,
+)
+@fake_checkpoints
+def test_from_initial_conditions_with_no_checkpoint_file(ckpt, ensemble_members, kwargs, shape):
+    """Test running with no checkpoint file"""
+    ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+
+    from anemoi.inference.checkpoint import Checkpoint
+
+    metadata = Checkpoint(ckpt_full_path)._metadata  # type: ignore
+
+    kwargs.pop("date", None)
+
+    action = from_initial_conditions(
+        "non_existent_checkpoint.ckpt", None, ensemble_members=ensemble_members, metadata=metadata, **kwargs
+    )
     shape.pop("date", None)
     assert_shape(action, shape)
 

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from anemoi.inference.testing import fake_checkpoints
+from earthkit.workflows.fluent import nodetree_arrays
 from xarray import DataArray, DataTree
 
 from earthkit.workflows.plugins.anemoi.fluent import Action, Inference, from_config, from_initial_conditions, from_input
@@ -225,3 +226,70 @@ def test_from_initial_conditions_from_infer(ckpt, ensemble_members, kwargs, shap
 
     action = init_conditions.infer(ckpt_full_path, **kwargs)
     assert_shape(action, shape)
+
+
+# --- payload_metadata propagation ---
+
+PAYLOAD_METADATA = {"source": "test", "run_id": "abc123"}
+SIMPLE_CKPT = "simple"
+SIMPLE_KWARGS = {"date": "2020-01-01", "lead_time": "1D"}
+
+
+def assert_payload_metadata(action: Action, expected: dict) -> None:
+    """Assert every node in action carries the expected metadata entries."""
+    for _, narray in nodetree_arrays(action.nodes):
+        for node in np.atleast_1d(narray.values).flatten():
+            for key, value in expected.items():
+                assert node.payload.metadata.get(key) == value, (
+                    f"Node {node.name!r} missing metadata {key!r}={value!r}, " f"got {node.payload.metadata}"
+                )
+
+
+@fake_checkpoints
+def test_from_input_propagates_payload_metadata():
+    """payload_metadata passed to from_input is stored on every result node."""
+    ckpt = (Path(__file__).parent / f"checkpoints/{SIMPLE_CKPT}.yaml").absolute()
+    action = from_input(ckpt, "dummy", payload_metadata=PAYLOAD_METADATA, **SIMPLE_KWARGS)
+    assert_payload_metadata(action, PAYLOAD_METADATA)
+
+
+@fake_checkpoints
+def test_from_initial_conditions_propagates_payload_metadata():
+    """payload_metadata passed to from_initial_conditions is stored on every result node."""
+    ckpt = (Path(__file__).parent / f"checkpoints/{SIMPLE_CKPT}.yaml").absolute()
+    kwargs = SIMPLE_KWARGS.copy()
+    kwargs.pop("date")
+    action = from_initial_conditions(ckpt, None, payload_metadata=PAYLOAD_METADATA, **kwargs)
+    assert_payload_metadata(action, PAYLOAD_METADATA)
+
+
+@fake_checkpoints
+def test_from_config_propagates_payload_metadata(mock_config):
+    """payload_metadata passed to from_config is stored on every result node."""
+    ckpt = (Path(__file__).parent / f"checkpoints/{SIMPLE_CKPT}.yaml").absolute()
+    action = from_config(
+        mock_config,
+        payload_metadata=PAYLOAD_METADATA,
+        checkpoint=str(ckpt),
+        input="dummy",
+        **SIMPLE_KWARGS,
+    )
+    assert_payload_metadata(action, PAYLOAD_METADATA)
+
+
+@fake_checkpoints
+def test_inference_from_input_propagates_payload_metadata():
+    """payload_metadata passed to Inference.from_input is stored on every result node."""
+    ckpt = (Path(__file__).parent / f"checkpoints/{SIMPLE_CKPT}.yaml").absolute()
+    inference = Inference(ckpt, lead_time=SIMPLE_KWARGS["lead_time"])
+    action = inference.from_input("dummy", SIMPLE_KWARGS["date"], payload_metadata=PAYLOAD_METADATA)
+    assert_payload_metadata(action, PAYLOAD_METADATA)
+
+
+@fake_checkpoints
+def test_inference_from_initial_conditions_propagates_payload_metadata():
+    """payload_metadata passed to Inference.from_initial_conditions is stored on every result node."""
+    ckpt = (Path(__file__).parent / f"checkpoints/{SIMPLE_CKPT}.yaml").absolute()
+    inference = Inference(ckpt, lead_time=SIMPLE_KWARGS["lead_time"])
+    action = inference.from_initial_conditions(None, payload_metadata=PAYLOAD_METADATA)
+    assert_payload_metadata(action, PAYLOAD_METADATA)

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -16,7 +16,7 @@ import pytest
 from anemoi.inference.testing import fake_checkpoints
 from xarray import DataArray, DataTree
 
-from earthkit.workflows.plugins.anemoi.fluent import Action, from_config, from_initial_conditions, from_input
+from earthkit.workflows.plugins.anemoi.fluent import Action, Inference, from_config, from_initial_conditions, from_input
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
 
 STANDARD_INFERENCE_TESTS = [
@@ -90,6 +90,17 @@ def test_from_input(ckpt, ensemble_members, kwargs, shape):
     assert_shape(action, shape)
 
 
+@pytest.mark.parametrize("ckpt, ensemble_members, kwargs, shape", STANDARD_INFERENCE_TESTS)
+@fake_checkpoints
+def test_inference_from_input(ckpt, ensemble_members, kwargs, shape):
+    """Test running from input using the class API"""
+    ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+
+    inference = Inference(ckpt_full_path, lead_time=kwargs["lead_time"])
+    action = inference.from_input("dummy", kwargs["date"], ensemble_members=ensemble_members)
+    assert_shape(action, shape)
+
+
 @pytest.mark.parametrize(
     "ckpt, ensemble_members, kwargs, shape",
     STANDARD_INFERENCE_TESTS,
@@ -113,6 +124,8 @@ def test_from_config(mock_config, ckpt, ensemble_members, kwargs, shape):
 def test_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape):
     """Test running from initial conditions"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
     kwargs.pop("date", None)
 
     action = from_initial_conditions(ckpt_full_path, None, ensemble_members=ensemble_members, **kwargs)
@@ -125,9 +138,29 @@ def test_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape
     STANDARD_INFERENCE_TESTS,
 )
 @fake_checkpoints
+def test_inference_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape):
+    """Test running from initial conditions using the class API"""
+    ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
+    kwargs.pop("date", None)
+
+    inference = Inference(ckpt_full_path, lead_time=kwargs.pop("lead_time"))
+    action = inference.from_initial_conditions(None, ensemble_members=ensemble_members, **kwargs)
+    shape.pop("date", None)
+    assert_shape(action, shape)
+
+
+@pytest.mark.parametrize(
+    "ckpt, ensemble_members, kwargs, shape",
+    STANDARD_INFERENCE_TESTS,
+)
+@fake_checkpoints
 def test_from_initial_conditions_with_no_checkpoint_file(ckpt, ensemble_members, kwargs, shape):
     """Test running with no checkpoint file"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
 
     from anemoi.inference.checkpoint import Checkpoint
 
@@ -150,6 +183,8 @@ def test_from_initial_conditions_with_no_checkpoint_file(ckpt, ensemble_members,
 def test_from_initial_conditions_from_action(ckpt, ensemble_members, kwargs, shape):
     """Test running from initial conditions"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
     kwargs.pop("date", None)
 
     from earthkit.workflows import fluent
@@ -173,6 +208,8 @@ def test_from_initial_conditions_from_action(ckpt, ensemble_members, kwargs, sha
 def test_from_initial_conditions_from_infer(ckpt, ensemble_members, kwargs, shape):
     """Test running from initial conditions"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
     kwargs.pop("date", None)
 
     from earthkit.workflows import fluent

--- a/tests/test_fluent_helpers.py
+++ b/tests/test_fluent_helpers.py
@@ -1,0 +1,54 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from earthkit.workflows.plugins.anemoi.fluent import _get_initial_conditions_source
+from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+
+@pytest.mark.parametrize(
+    "date, ensemble_members, perturbation, shape",
+    [
+        ["2000-01-01", 1, False, {"date": 1}],
+        ["2000-01-01", [2], False, {"date": 1}],
+        ["2000-01-01", range(1, 2), False, {"date": 1}],
+        ["2000-01-01", 10, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", range(10), False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", range(10, 20), False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", 10, True, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", 51, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
+        ["2000-01-01", 51, True, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
+        [-1, 51, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
+    ],
+)
+def test_get_initial_conditions_action(mock_config, date, ensemble_members, perturbation, shape):
+    """Test getting initial conditions"""
+    action = _get_initial_conditions_source(
+        mock_config, date, ensemble_members, initial_condition_perturbation=perturbation
+    )
+
+    for dim in shape:
+        assert dim in action.nodes.dims
+        assert action.nodes.coords[dim].size == shape[dim]
+
+
+@pytest.mark.parametrize(
+    "date, ensemble_members, perturbation, shape",
+    [
+        ["2000-01-01", 0, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", -1, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+    ],
+)
+def test_get_initial_conditions_action_fail(mock_config, date, ensemble_members, perturbation, shape):
+    """Test failing to get initial conditions"""
+    with pytest.raises(ValueError):
+        _ = _get_initial_conditions_source(
+            mock_config, date, ensemble_members, initial_condition_perturbation=perturbation
+        )

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -8,78 +8,9 @@
 # nor does it submit to any jurisdiction.
 
 
-from pathlib import Path
-
-import pytest
 from anemoi.inference.testing import fake_checkpoints
-from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
 
 from earthkit.workflows.plugins.anemoi.inference import _get_initial_conditions_from_config
-from earthkit.workflows.plugins.anemoi.inference import get_initial_conditions_source
-from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
-
-
-@pytest.fixture
-@fake_checkpoints
-def mock_config(tmp_path: Path):
-    import yaml
-
-    parent_dir = Path(__file__).parent
-    config_path = parent_dir / "configs" / "simple.yaml"
-
-    config_dict = yaml.safe_load(config_path.read_text())
-    config_dict["checkpoint"] = f"{parent_dir}/{config_dict['checkpoint']}"
-
-    with open(tmp_path / "simple.yaml", "w") as f:
-        yaml.safe_dump(config_dict, f)
-
-    tmp_path = tmp_path / "simple.yaml"
-
-    return MockRunConfiguration.load(
-        str((tmp_path).absolute()),
-        overrides=dict(runner="testing", device="cpu", input="dummy"),
-    )
-
-
-@pytest.mark.parametrize(
-    "date, ensemble_members, perturbation, shape",
-    [
-        ["2000-01-01", 1, False, {"date": 1}],
-        ["2000-01-01", [2], False, {"date": 1}],
-        ["2000-01-01", range(1, 2), False, {"date": 1}],
-        ["2000-01-01", 10, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", range(10), False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", range(10, 20), False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", 10, True, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", 51, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
-        ["2000-01-01", 51, True, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
-        [-1, 51, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
-    ],
-)
-def test_get_initial_conditions_action(mock_config, date, ensemble_members, perturbation, shape):
-    """Test getting initial conditions"""
-    action = get_initial_conditions_source(
-        mock_config, date, ensemble_members, initial_condition_perturbation=perturbation
-    )
-
-    for dim in shape:
-        assert dim in action.nodes.dims
-        assert action.nodes.coords[dim].size == shape[dim]
-
-
-@pytest.mark.parametrize(
-    "date, ensemble_members, perturbation, shape",
-    [
-        ["2000-01-01", 0, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", -1, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-    ],
-)
-def test_get_initial_conditions_action_fail(mock_config, date, ensemble_members, perturbation, shape):
-    """Test failing to get initial conditions"""
-    with pytest.raises(ValueError):
-        _ = get_initial_conditions_source(
-            mock_config, date, ensemble_members, initial_condition_perturbation=perturbation
-        )
 
 
 @fake_checkpoints


### PR DESCRIPTION
### Description
Seperate out configuration from runtime deps,
Allows for inference to not be required as installed in the configuration. 

Uses a `Metadata` like object as the communication object.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- readthedocs-preview earthkit-workflows-anemoi start -->
----
📚 Documentation preview 📚: https://earthkit-workflows-anemoi--25.org.readthedocs.build/en/25/

<!-- readthedocs-preview earthkit-workflows-anemoi end -->