### PR TITLE
refactor from_input and from_initial_condition into an Inference class

### DIFF
--- a/docs/usage/inference.rst
+++ b/docs/usage/inference.rst
@@ -23,8 +23,8 @@ the following code:
    model_action = inference.from_input("mars", "2022-01-01T00:00")
    model_action
 
-This will use load the checkpoint, and use the ``mars`` input source,
-with a lead_time of 7 days. It is possible to configure the input source
+This will load the checkpoint and use the ``mars`` input source,
+with a lead time of 7 days. It is possible to configure the input source
 just like you would do with the ``anemoi-inference`` interfaces.
 
 *************

--- a/docs/usage/inference.rst
+++ b/docs/usage/inference.rst
@@ -23,9 +23,9 @@ the following code:
    model_action = inference.from_input("mars", "2022-01-01T00:00")
    model_action
 
-This will load the checkpoint and use the ``mars`` input source,
-with a lead time of 7 days. It is possible to configure the input source
-just like you would do with the ``anemoi-inference`` interfaces.
+This will load the checkpoint and use the ``mars`` input source, with a
+lead time of 7 days. It is possible to configure the input source just
+like you would do with the ``anemoi-inference`` interfaces.
 
 *************
  From Source

--- a/docs/usage/inference.rst
+++ b/docs/usage/inference.rst
@@ -19,9 +19,8 @@ the following code:
 
    CKPT = {"huggingface": "ecmwf/aifs-single-1.0"}
 
-   model_action = anemoi_workflows.fluent.from_input(
-       CKPT, "mars", "2022-01-01T00:00", lead_time="7D"
-   )
+   inference = anemoi_workflows.fluent.Inference(CKPT, lead_time="7D")
+   model_action = inference.from_input("mars", "2022-01-01T00:00")
    model_action
 
 This will use load the checkpoint, and use the ``mars`` input source,
@@ -33,7 +32,7 @@ just like you would do with the ``anemoi-inference`` interfaces.
 *************
 
 If more complex initial conditions are required, you can use the
-``infer`` method on an existing source node.
+``from_initial_conditions`` method on an ``Inference`` instance.
 
 .. code:: python
 
@@ -43,7 +42,8 @@ If more complex initial conditions are required, you can use the
    SOURCE_NODES: fluent.Action
    CKPT = {"huggingface": "ecmwf/aifs-single-1.0"}
 
-   SOURCE_NODES.anemoi.infer(CKPT, lead_time="7D")
+   inference = anemoi_workflows.fluent.Inference(CKPT, lead_time="7D")
+   inference.from_initial_conditions(SOURCE_NODES)
 
 This will use the existing source nodes as the initial conditions, and
 run the inference task with the specified checkpoint, lead time. If the

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -222,15 +222,29 @@ class Inference:
         """
         self.ckpt = ckpt
         self.lead_time = lead_time
-        self.environment = environment
-        self.metadata = _get_metadata(ckpt, metadata=metadata)
-        self.kwargs = kwargs
+        self.environment: ENVIRONMENT = environment if environment is not None else []
+        self.metadata: Metadata = _get_metadata(ckpt, metadata=metadata)
+        self.kwargs: dict[str, Any] = kwargs
 
     def _config(self, **kwargs: Any) -> dict[str, Any]:
         return {"checkpoint": self.ckpt, **self.kwargs, **kwargs}
 
-    def _environment(self, environment: ENVIRONMENT | None = None) -> ENVIRONMENT | None:
-        return environment if environment is not None else self.environment
+    def _run_model(
+        self,
+        config: RunConfiguration | dict,
+        input_state_source: fluent.Action,
+        *,
+        payload_metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> fluent.Action:
+        return _run_model(
+            self.metadata,
+            config,
+            input_state_source,
+            self.lead_time,
+            payload_metadata=payload_metadata,
+            **kwargs,
+        )
 
     def from_input(
         self,
@@ -238,7 +252,6 @@ class Inference:
         date: DATE,
         *,
         ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
-        environment: ENVIRONMENT | None = None,
         **kwargs: Any,
     ) -> fluent.Action:
         """
@@ -253,8 +266,6 @@ class Inference:
             Date to get initial conditions for
         ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
             Number of ensemble members to run, None will run a single instance, by default None
-        environment : ENVIRONMENT, optional
-            Environment to use for this action. If not provided, uses the class environment.
         kwargs : dict
             Additional arguments to pass to the runner configuration
 
@@ -271,7 +282,7 @@ class Inference:
         """
         config = self._config(input=input, **kwargs)
         environment_dict = crack_environment(
-            self._environment(environment),
+            self.environment,
             ["inference", "initial_conditions"],
         )
 
@@ -282,20 +293,17 @@ class Inference:
             payload_metadata={"environment": environment_dict["initial_conditions"]},
         )
 
-        return _run_model(
-            self.metadata,
+        return self._run_model(
             config,
             input_state_source,
-            self.lead_time,
             payload_metadata={"environment": environment_dict["inference"]},
         )
 
     def from_initial_conditions(
         self,
-        initial_conditions: State | fluent.Action | fluent.Payload | Callable,
+        initial_conditions: State | None | fluent.Action | fluent.Payload | Callable,
         *,
         ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
-        environment: ENVIRONMENT | None = None,
         **kwargs: Any,
     ) -> fluent.Action:
         """
@@ -303,9 +311,10 @@ class Inference:
 
         Parameters
         ----------
-        initial_conditions : State | fluent.Action | fluent.Payload | Callable
+        initial_conditions : State | None | fluent.Action | fluent.Payload | Callable
             Initial conditions for the model
-            Can be other fluent actions, payloads, or a callable, or a State.
+            Can be other fluent actions, payloads, a callable, a State, or None.
+            None creates a source node that yields None.
             If a fluent action and multiple ensemble member initial conditions
             are included, the dimension must be named `ensemble_member`.
         ensemble_members : Optional[ENSEMBLE_MEMBER_SPECIFICATION], optional
@@ -313,8 +322,6 @@ class Inference:
             If initial_conditions is a fluent action with multiple ensemble
             members, this argument can be set to None, and the number of
             ensemble members will be inferred from the action.
-        environment : ENVIRONMENT, optional
-            Environment to use for this action. If not provided, uses the class environment.
         kwargs : dict
             Additional arguments to pass to the runner configuration
 
@@ -330,7 +337,7 @@ class Inference:
         >>> inference.from_initial_conditions(init_conditions)
         """
         config = self._config(**kwargs)
-        environment_dict = crack_environment(self._environment(environment), ["inference"])
+        environment_dict = crack_environment(self.environment, ["inference"])
 
         if isinstance(initial_conditions, fluent.Action):
             initial_conditions_source = initial_conditions
@@ -362,11 +369,9 @@ class Inference:
                 (ENSEMBLE_DIMENSION_NAME, parsed_ensemble_members),  # type: ignore
             )
 
-        return _run_model(
-            self.metadata,
+        return self._run_model(
             config,
             ens_initial_conditions,
-            self.lead_time,
             payload_metadata={"environment": environment_dict["inference"]},
         )
 
@@ -516,7 +521,7 @@ def from_input(
 
 def from_initial_conditions(
     ckpt: VALID_CKPT,
-    initial_conditions: State | fluent.Action | fluent.Payload | Callable,
+    initial_conditions: State | None | fluent.Action | fluent.Payload | Callable,
     lead_time: LEAD_TIME,
     *,
     ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
@@ -531,9 +536,10 @@ def from_initial_conditions(
     ----------
     ckpt : VALID_CKPT
         Checkpoint to load
-    initial_conditions : State | fluent.Action | fluent.Payload | Callable
+    initial_conditions : State | None | fluent.Action | fluent.Payload | Callable
         Initial conditions for the model
-        Can be other fluent actions, payloads, or a callable, or a State.
+        Can be other fluent actions, payloads, a callable, a State, or None.
+        None creates a source node that yields None.
         If a fluent action and multiple ensemble member initial conditions
         are included, the dimension must be named `ensemble_member`.
     lead_time : LEAD_TIME

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -193,6 +193,184 @@ def _run_model(
     return model_results.expand_as_qube(qube.remove_by_key("step"))
 
 
+class Inference:
+    """Build fluent workflow actions for one anemoi inference setup."""
+
+    def __init__(
+        self,
+        ckpt: VALID_CKPT,
+        lead_time: LEAD_TIME,
+        *,
+        environment: ENVIRONMENT | None = None,
+        metadata: Metadata | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        ckpt : VALID_CKPT
+            Checkpoint to load
+        lead_time : LEAD_TIME
+            Lead time to run out to. Can be a string,
+            i.e. `1H`, `1D`, int, or a datetime.timedelta
+        environment : ENVIRONMENT, optional
+            Environment to run the model in, by default None
+        metadata : Optional[Metadata], optional
+            `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+        """
+        self.ckpt = ckpt
+        self.lead_time = lead_time
+        self.environment = environment
+        self.metadata = _get_metadata(ckpt, metadata=metadata)
+        self.kwargs = kwargs
+
+    def _config(self, **kwargs: Any) -> dict[str, Any]:
+        return {"checkpoint": self.ckpt, **self.kwargs, **kwargs}
+
+    def _environment(self, environment: ENVIRONMENT | None = None) -> ENVIRONMENT | None:
+        return environment if environment is not None else self.environment
+
+    def from_input(
+        self,
+        input: str | dict[str, Any],
+        date: DATE,
+        *,
+        ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+        environment: ENVIRONMENT | None = None,
+        **kwargs: Any,
+    ) -> fluent.Action:
+        """
+        Run an anemoi inference model from a given input source.
+
+        Parameters
+        ----------
+        input : str | dict[str, Any]
+            `anemoi.inference` input source.
+            Can be `mars`, `grib`, etc or a dictionary of input configuration,
+        date : DATE
+            Date to get initial conditions for
+        ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
+            Number of ensemble members to run, None will run a single instance, by default None
+        environment : ENVIRONMENT, optional
+            Environment to use for this action. If not provided, uses the class environment.
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+
+        Returns
+        -------
+        fluent.Action
+            earthkit.workflows action of the model results
+
+        Examples
+        -------
+        >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
+        >>> inference = Inference("anemoi_model.ckpt", lead_time = "10D")
+        >>> inference.from_input("mars", date = "2021-01-01T00:00:00")
+        """
+        config = self._config(input=input, **kwargs)
+        environment_dict = crack_environment(
+            self._environment(environment),
+            ["inference", "initial_conditions"],
+        )
+
+        input_state_source = _get_initial_conditions_source(
+            config=config,
+            date=date,
+            ensemble_members=ensemble_members,
+            payload_metadata={"environment": environment_dict["initial_conditions"]},
+        )
+
+        return _run_model(
+            self.metadata,
+            config,
+            input_state_source,
+            self.lead_time,
+            payload_metadata={"environment": environment_dict["inference"]},
+        )
+
+    def from_initial_conditions(
+        self,
+        initial_conditions: State | fluent.Action | fluent.Payload | Callable,
+        *,
+        ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
+        environment: ENVIRONMENT | None = None,
+        **kwargs: Any,
+    ) -> fluent.Action:
+        """
+        Run an anemoi inference model from initial conditions.
+
+        Parameters
+        ----------
+        initial_conditions : State | fluent.Action | fluent.Payload | Callable
+            Initial conditions for the model
+            Can be other fluent actions, payloads, or a callable, or a State.
+            If a fluent action and multiple ensemble member initial conditions
+            are included, the dimension must be named `ensemble_member`.
+        ensemble_members : Optional[ENSEMBLE_MEMBER_SPECIFICATION], optional
+            Number of ensemble members to run.
+            If initial_conditions is a fluent action with multiple ensemble
+            members, this argument can be set to None, and the number of
+            ensemble members will be inferred from the action.
+        environment : ENVIRONMENT, optional
+            Environment to use for this action. If not provided, uses the class environment.
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+
+        Returns
+        -------
+        fluent.Action
+            earthkit.workflows action of the model results
+
+        Examples
+        --------
+        >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
+        >>> inference = Inference("anemoi_model.ckpt", lead_time = "10D")
+        >>> inference.from_initial_conditions(init_conditions)
+        """
+        config = self._config(**kwargs)
+        environment_dict = crack_environment(self._environment(environment), ["inference"])
+
+        if isinstance(initial_conditions, fluent.Action):
+            initial_conditions_source = initial_conditions
+        elif isinstance(initial_conditions, (Callable, fluent.Payload)):
+            initial_conditions_source = fluent.from_source([initial_conditions])  # type: ignore
+        else:
+            initial_conditions_source = fluent.from_source(
+                [fluent.Payload(lambda: initial_conditions)],
+                dims=["date"],
+            )  # type: ignore
+
+        if ENSEMBLE_DIMENSION_NAME in initial_conditions_source.nodes.dims:
+            if ensemble_members is None:
+                ensemble_members = len(initial_conditions_source.nodes.coords[ENSEMBLE_DIMENSION_NAME])
+
+            parsed_ensemble_members = parse_ensemble_members(ensemble_members)
+
+            if len(initial_conditions_source.nodes.coords[ENSEMBLE_DIMENSION_NAME]) != len(parsed_ensemble_members):
+                raise ValueError(
+                    "Number of ensemble members in initial conditions must match `ensemble_members` argument"
+                )
+            ens_initial_conditions = initial_conditions_source
+
+        else:
+            parsed_ensemble_members = parse_ensemble_members(ensemble_members)
+            ens_initial_conditions = initial_conditions_source.transform(
+                faked_ensemble_transform,
+                list(zip(parsed_ensemble_members)),  # type: ignore
+                (ENSEMBLE_DIMENSION_NAME, parsed_ensemble_members),  # type: ignore
+            )
+
+        return _run_model(
+            self.metadata,
+            config,
+            ens_initial_conditions,
+            self.lead_time,
+            payload_metadata={"environment": environment_dict["inference"]},
+        )
+
+
 def from_config(
     config: os.PathLike | dict[str, Any] | RunConfiguration,
     overrides: dict[str, Any] | None = None,
@@ -329,22 +507,10 @@ def from_input(
     >>> from earthkit.workflows.plugins.anemoi.fluent import from_input
     >>> from_input("anemoi_model.ckpt", "mars", date = "2021-01-01T00:00:00", lead_time = "10D")
     """
-    config = dict(checkpoint=ckpt, input=input, **kwargs)
-    environment = crack_environment(environment, ["inference", "initial_conditions"])
-
-    input_state_source = _get_initial_conditions_source(
-        config=config,
-        date=date,
+    return Inference(ckpt, lead_time, environment=environment, metadata=metadata, **kwargs).from_input(
+        input,
+        date,
         ensemble_members=ensemble_members,
-        payload_metadata={"environment": environment["initial_conditions"]},
-    )
-
-    return _run_model(
-        _get_metadata(ckpt, metadata=metadata),
-        config,
-        input_state_source,
-        lead_time,
-        payload_metadata={"environment": environment["inference"]},
     )
 
 
@@ -399,39 +565,9 @@ def from_initial_conditions(
     >>> from earthkit.workflows.plugins.anemoi.fluent import from_initial_conditions
     >>> from_initial_conditions("anemoi_model.ckpt", init_conditions, lead_time = "10D")
     """
-
-    config = dict(checkpoint=ckpt, **kwargs)
-    environment_dict = crack_environment(environment, ["inference"])
-
-    if isinstance(initial_conditions, fluent.Action):
-        initial_conditions = initial_conditions
-    elif isinstance(initial_conditions, (Callable, fluent.Payload)):
-        initial_conditions = fluent.from_source([initial_conditions])  # type: ignore
-    else:
-        initial_conditions = fluent.from_source([fluent.Payload(lambda: initial_conditions)], dims=["date"])  # type: ignore
-
-    if ENSEMBLE_DIMENSION_NAME in initial_conditions.nodes.dims:
-        if ensemble_members is None:
-            ensemble_members = len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME])
-
-        parsed_ensemble_members = parse_ensemble_members(ensemble_members)
-
-        if not len(initial_conditions.nodes.coords[ENSEMBLE_DIMENSION_NAME]) == len(parsed_ensemble_members):
-            raise ValueError("Number of ensemble members in initial conditions must match `ensemble_members` argument")
-        ens_initial_conditions = initial_conditions
-
-    else:
-        ens_initial_conditions = initial_conditions.transform(
-            faked_ensemble_transform,
-            list(zip(parse_ensemble_members(ensemble_members))),  # type: ignore
-            (ENSEMBLE_DIMENSION_NAME, parse_ensemble_members(ensemble_members)),  # type: ignore
-        )
-    return _run_model(
-        _get_metadata(ckpt, metadata=metadata),
-        config,
-        ens_initial_conditions,
-        lead_time,
-        payload_metadata={"environment": environment_dict["inference"]},
+    return Inference(ckpt, lead_time, environment=environment, metadata=metadata, **kwargs).from_initial_conditions(
+        initial_conditions,
+        ensemble_members=ensemble_members,
     )
 
 
@@ -775,6 +911,7 @@ fluent.Action.register("anemoi", Action)
 
 
 __all__ = [
+    "Inference",
     "from_config",
     "from_input",
     "from_initial_conditions",

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -16,7 +16,7 @@ import pytest
 from anemoi.inference.testing import fake_checkpoints
 from xarray import DataArray, DataTree
 
-from earthkit.workflows.plugins.anemoi.fluent import Action, from_config, from_initial_conditions, from_input
+from earthkit.workflows.plugins.anemoi.fluent import Action, Inference, from_config, from_initial_conditions, from_input
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
 
 STANDARD_INFERENCE_TESTS = [
@@ -90,6 +90,17 @@ def test_from_input(ckpt, ensemble_members, kwargs, shape):
     assert_shape(action, shape)
 
 
+@pytest.mark.parametrize("ckpt, ensemble_members, kwargs, shape", STANDARD_INFERENCE_TESTS)
+@fake_checkpoints
+def test_inference_from_input(ckpt, ensemble_members, kwargs, shape):
+    """Test running from input using the class API"""
+    ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+
+    inference = Inference(ckpt_full_path, lead_time=kwargs["lead_time"])
+    action = inference.from_input("dummy", kwargs["date"], ensemble_members=ensemble_members)
+    assert_shape(action, shape)
+
+
 @pytest.mark.parametrize(
     "ckpt, ensemble_members, kwargs, shape",
     STANDARD_INFERENCE_TESTS,
@@ -116,6 +127,24 @@ def test_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape
     kwargs.pop("date", None)
 
     action = from_initial_conditions(ckpt_full_path, None, ensemble_members=ensemble_members, **kwargs)
+    shape.pop("date", None)
+    assert_shape(action, shape)
+
+
+@pytest.mark.parametrize(
+    "ckpt, ensemble_members, kwargs, shape",
+    STANDARD_INFERENCE_TESTS,
+)
+@fake_checkpoints
+def test_inference_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape):
+    """Test running from initial conditions using the class API"""
+    ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
+    kwargs.pop("date", None)
+
+    inference = Inference(ckpt_full_path, lead_time=kwargs.pop("lead_time"))
+    action = inference.from_initial_conditions(None, ensemble_members=ensemble_members, **kwargs)
     shape.pop("date", None)
     assert_shape(action, shape)
 

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -124,6 +124,8 @@ def test_from_config(mock_config, ckpt, ensemble_members, kwargs, shape):
 def test_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape):
     """Test running from initial conditions"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
     kwargs.pop("date", None)
 
     action = from_initial_conditions(ckpt_full_path, None, ensemble_members=ensemble_members, **kwargs)
@@ -157,6 +159,8 @@ def test_inference_from_initial_conditions_from_none(ckpt, ensemble_members, kwa
 def test_from_initial_conditions_with_no_checkpoint_file(ckpt, ensemble_members, kwargs, shape):
     """Test running with no checkpoint file"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
 
     from anemoi.inference.checkpoint import Checkpoint
 
@@ -179,6 +183,8 @@ def test_from_initial_conditions_with_no_checkpoint_file(ckpt, ensemble_members,
 def test_from_initial_conditions_from_action(ckpt, ensemble_members, kwargs, shape):
     """Test running from initial conditions"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
     kwargs.pop("date", None)
 
     from earthkit.workflows import fluent
@@ -202,6 +208,8 @@ def test_from_initial_conditions_from_action(ckpt, ensemble_members, kwargs, sha
 def test_from_initial_conditions_from_infer(ckpt, ensemble_members, kwargs, shape):
     """Test running from initial conditions"""
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
+    kwargs = kwargs.copy()
+    shape = shape.copy()
     kwargs.pop("date", None)
 
     from earthkit.workflows import fluent


### PR DESCRIPTION
This pull request introduces a new `Inference` class to the `anemoi.fluent` plugin, providing a more object-oriented and flexible API for running inference workflows. It refactors the existing procedural functions (`from_input`, `from_initial_conditions`) to use this new class under the hood, updates documentation and tests to reflect the new usage, and maintains backward compatibility. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- readthedocs-preview earthkit-workflows-anemoi start -->
----
📚 Documentation preview 📚: https://earthkit-workflows-anemoi--26.org.readthedocs.build/en/26/

<!-- readthedocs-preview earthkit-workflows-anemoi end -->