### PR TITLE
feat: Add seperate get_input

### DIFF
--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -235,6 +235,10 @@ class Inference:
         self.kwargs = kwargs
 
     def _config(self, **kwargs: Any) -> dict[str, Any]:
+        if set(*kwargs.keys()) & {"checkpoint", *self.kwargs.keys()}:
+            raise ValueError(
+                f"Cannot override checkpoint or keys set in the constructor: {set(kwargs.keys()) & {'checkpoint', *self.kwargs.keys()}}"
+            )
         return {"checkpoint": self.ckpt, **self.kwargs, **kwargs}
 
     def _run_model(
@@ -383,6 +387,38 @@ class Inference:
             config,
             ens_initial_conditions,
             payload_metadata={"environment": environment_dict["inference"]},
+        )
+
+    def get_initial_conditions(self, input: str | dict[str, Any], date: DATE, **kwargs: Any) -> fluent.Action:
+        """
+        Get initial conditions for an anemoi inference model.
+
+        Parameters
+        ----------
+        input : str | dict[str, Any]
+            Input data for the model
+        date : DATE
+            Date for the initial conditions
+        kwargs : dict
+            Additional arguments to pass to the runner configuration
+
+        Returns
+        -------
+        fluent.Action
+            earthkit.workflows action of the initial conditions
+
+        Examples
+        --------
+        >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
+        >>> inference = Inference("anemoi_model.ckpt", lead_time = "10D")
+        >>> inference.get_initial_conditions("mars", date = "2021-01-01T00:00:00")
+        """
+        config = self._config(input=input, **kwargs)
+        environment_dict = crack_environment(self.environment, ["initial_conditions"])
+        return _get_initial_conditions_source(
+            config=config,
+            date=date,
+            payload_metadata={"environment": environment_dict["initial_conditions"]},
         )
 
 
@@ -587,6 +623,53 @@ def from_initial_conditions(
     return Inference(ckpt, lead_time, environment=environment, metadata=metadata, **kwargs).from_initial_conditions(
         initial_conditions,
         ensemble_members=ensemble_members,
+    )
+
+
+@capture_payload_metadata
+def get_initial_conditions(
+    ckpt: VALID_CKPT,
+    input: str | dict[str, Any],
+    date: DATE,
+    *,
+    environment: ENVIRONMENT | None = None,
+    metadata: Metadata | None = None,
+    **kwargs: Any,
+) -> fluent.Action:
+    """
+    Get initial conditions for an anemoi inference model
+
+    Parameters
+    ----------
+    ckpt : VALID_CKPT
+        Checkpoint to load
+    input : str | dict[str, Any]
+        Input data for the model
+    date : DATE
+        Date for the initial conditions
+    environment : Optional[list[str]], optional
+        Environment to run the model in, by default None
+        If None, will use the current environment
+        Should be set to strings, as if used in pip install,
+        e.g. `["anemoi-models==0.3.1"]`
+    metadata : Optional[Metadata], optional
+        `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
+    kwargs : dict
+        Additional arguments to pass to the configuration
+
+    Returns
+    -------
+    fluent.Action
+        earthkit.workflows action of the initial conditions
+
+    Examples
+    --------
+    >>> from earthkit.workflows.plugins.anemoi.fluent import get_initial_conditions
+    >>> get_initial_conditions("anemoi_model.ckpt", "input_data", date = "2021-01-01T00:00:00")
+    """
+    return Inference(ckpt, environment=environment, metadata=metadata, **kwargs).get_initial_conditions(
+        input,
+        date,
     )
 
 

--- a/src/earthkit/workflows/plugins/anemoi/utils.py
+++ b/src/earthkit/workflows/plugins/anemoi/utils.py
@@ -230,7 +230,7 @@ def parse_ensemble_members(ensemble_members: "ENSEMBLE_MEMBER_SPECIFICATION | No
     return list(ensemble_members)
 
 
-def _empty_payload(x: dict, ens_mem: int | None) -> dict:
+def expose_ensemble_dimension(x: dict, ens_mem: int | None) -> dict:
     assert isinstance(x, dict), "Input state must be a dictionary"
     if ens_mem is not None:
         x["ensemble_member"] = ens_mem
@@ -239,7 +239,7 @@ def _empty_payload(x: dict, ens_mem: int | None) -> dict:
 
 def faked_ensemble_transform(act: fluent.Action, ens_num: int | None = None) -> fluent.Action:
     """Transform the action to simulate ensemble members"""
-    return act.map(fluent.Payload(_empty_payload, [fluent.Node.input_name(0), ens_num]))
+    return act.map(fluent.Payload(expose_ensemble_dimension, [fluent.Node.input_name(0), ens_num]))
 
 
 def _add_self_to_environment(environment: E) -> E:
@@ -249,7 +249,7 @@ def _add_self_to_environment(environment: E) -> E:
     Parameters
     ----------
     environment : list[str] | dict[str, list[str]]
-        Environment list to self in place to
+        Environment list to add self in place to
 
     Returns
     -------


### PR DESCRIPTION
### Description
This pull request introduces enhancements and minor fixes to the Anemoi plugin in the `earthkit.workflows` package, focusing on improving initial condition handling and ensemble member simulation. The main changes include new methods for obtaining initial conditions, stricter configuration validation, and improved naming for utility functions.

**Enhancements to initial condition handling:**

* Added a new `get_initial_conditions` method to the `Inference` class, enabling users to retrieve initial conditions for inference models with clear documentation and usage examples.
* Introduced a top-level `get_initial_conditions` function (decorated with `@capture_payload_metadata`) that creates an `Inference` instance and calls its `get_initial_conditions` method, streamlining access to initial conditions in workflows.

**Configuration validation improvements:**

* Updated the `_config` method in the `Inference` class to raise a `ValueError` if users attempt to override the `checkpoint` or any constructor-specified keys, preventing configuration conflicts.

**Utility function renaming and documentation:**

* Renamed the internal function `_empty_payload` to `expose_ensemble_dimension` and updated its usage in `faked_ensemble_transform` for clearer intent and readability. [[1]](diffhunk://#diff-cd21dc0eb96d6d326fceabd5787adc2dd2249524ae9e67e7926799113bcef0a1L233-R233) [[2]](diffhunk://#diff-cd21dc0eb96d6d326fceabd5787adc2dd2249524ae9e67e7926799113bcef0a1L242-R242)
* Fixed a typo in the docstring of `_add_self_to_environment` for improved documentation clarity.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
