### PR TITLE
feat: expand test suite and fix ensemble dimension bug

### DIFF
--- a/.github/workflows/python-pull-request.yml
+++ b/.github/workflows/python-pull-request.yml
@@ -16,10 +16,20 @@ jobs:
     with:
       skip-hooks: "no-commit-to-branch"
 
-  checks:
+  unit-tests:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     uses: ecmwf/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
     with:
       python-version: ${{ matrix.python-version }}
+      custom-pytest: "pytest --ignore=tests/integration"
+
+  integration-tests:
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    uses: ecmwf/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
+    with:
+      python-version: ${{ matrix.python-version }}
+      custom-pytest: "pytest tests/integration/"

--- a/.github/workflows/python-pull-request.yml
+++ b/.github/workflows/python-pull-request.yml
@@ -23,7 +23,6 @@ jobs:
     uses: ecmwf/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
     with:
       python-version: ${{ matrix.python-version }}
-      custom-pytest: "pytest --ignore=tests/integration"
 
   integration-tests:
     strategy:
@@ -32,4 +31,4 @@ jobs:
     uses: ecmwf/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
     with:
       python-version: ${{ matrix.python-version }}
-      custom-pytest: "pytest tests/integration/"
+      skip-tests: "integration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,10 @@ profile = "black"
 log_cli = true
 log_cli_level = "DEBUG"
 testpaths = [ "tests/" ]
-addopts = "-n8"
-
-# Run integration tests separately: pytest tests/integration/
-# Run unit tests only: pytest tests/ --ignore=tests/integration
+addopts = "-n8 -m 'not integration'"
+markers = [
+  "integration: integration tests (deselected by default, run with: pytest -m integration)",
+]
 
 [tool.uv.sources]
 earthkit-workflows-anemoi = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,5 +86,8 @@ log_cli_level = "DEBUG"
 testpaths = [ "tests/" ]
 addopts = "-n8"
 
+# Run integration tests separately: pytest tests/integration/
+# Run unit tests only: pytest tests/ --ignore=tests/integration
+
 [tool.uv.sources]
 earthkit-workflows-anemoi = { workspace = true }

--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -26,6 +26,7 @@ from earthkit.data.utils.dates import to_datetime
 from earthkit.workflows import mark
 
 from .runner import CascadeRunner
+from .types import ENSEMBLE_DIMENSION_NAME
 
 if TYPE_CHECKING:
     from anemoi.inference.input import Input
@@ -52,7 +53,7 @@ def _get_initial_conditions_ens(input: Input, ens_mem: int, date: DATE) -> State
 
     input_state = input.create_input_state(date=to_datetime(date))
     assert isinstance(input_state, dict), "Input state must be a dictionary"
-    input_state["ensemble_member"] = ens_mem
+    input_state[ENSEMBLE_DIMENSION_NAME] = ens_mem
 
     return input_state
 
@@ -182,7 +183,11 @@ def convert_to_fieldlist(
                 "shortName": variable.param,
                 "param": variable.param,
                 "latitudes": state["latitudes"],
-                "longitudes": np.where(state["longitudes"] > 180, state["longitudes"] - 360, state["longitudes"]),
+                "longitudes": np.where(
+                    state["longitudes"] > 180,
+                    state["longitudes"] - 360,
+                    state["longitudes"],
+                ),
             }
         )
         if "levtype" in variable.grib_keys:
@@ -197,7 +202,10 @@ def convert_to_fieldlist(
 
 @mark.needs_gpu
 def run_as_earthkit(
-    input_state: dict, runner: CascadeRunner, lead_time: LEAD_TIME, extra_metadata: dict[str, Any] | None = None
+    input_state: dict,
+    runner: CascadeRunner,
+    lead_time: LEAD_TIME,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> Generator[ekd.SimpleFieldList]:
     """
     Run the model and yield the results as earthkit FieldList
@@ -220,7 +228,7 @@ def run_as_earthkit(
     """
 
     initial_date: datetime.datetime = input_state["date"]
-    ensemble_member = input_state.get("ensemble_member", None)
+    ensemble_member = input_state.get(ENSEMBLE_DIMENSION_NAME, None)
     extra_metadata = extra_metadata or {}
 
     post_processors = runner.create_post_processors()
@@ -253,7 +261,10 @@ def run_as_earthkit_from_config(
 
 @mark.needs_gpu
 def collect_as_earthkit(
-    input_state: dict, runner: CascadeRunner, lead_time: LEAD_TIME, extra_metadata: dict[str, Any] | None = None
+    input_state: dict,
+    runner: CascadeRunner,
+    lead_time: LEAD_TIME,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> ekd.SimpleFieldList:
     """
     Collect the results of the model run as earthkit FieldList

--- a/src/earthkit/workflows/plugins/anemoi/utils.py
+++ b/src/earthkit/workflows/plugins/anemoi/utils.py
@@ -18,7 +18,7 @@ from qubed import Qube
 
 from earthkit.workflows import fluent
 
-from .types import ENVIRONMENT
+from .types import ENSEMBLE_DIMENSION_NAME, ENVIRONMENT
 
 if TYPE_CHECKING:
     from anemoi.inference.metadata import Metadata
@@ -97,7 +97,10 @@ def expansion_qube_from_metadata(metadata: "Metadata | dict[str, Any]", lead_tim
 
 
 def expansion_qube_from_variables(
-    variables: list[str], variables_metadata: dict, model_step: int, lead_time: "LEAD_TIME"
+    variables: list[str],
+    variables_metadata: dict,
+    model_step: int,
+    lead_time: "LEAD_TIME",
 ) -> Qube:
     """Create a Qube object from a list of variable names, their metadata, model step, and lead time.
 
@@ -160,14 +163,24 @@ def expansion_qube_from_variables(
     return _expansion_qube(variables, variables_metadata, model_step, lead_time)
 
 
-def _expansion_qube(variables: list[str], variables_metadata: dict, model_step: int, lead_time: "LEAD_TIME") -> Qube:
+def _expansion_qube(
+    variables: list[str],
+    variables_metadata: dict,
+    model_step: int,
+    lead_time: "LEAD_TIME",
+) -> Qube:
     """Create a Qube object from elements from model metadata and lead time."""
     surface_variables = {variables_metadata[var] for var in variables if variables_metadata[var].is_surface_level}
     pressure_variables = {variables_metadata[var] for var in variables if variables_metadata[var].is_pressure_level}
     model_variables = {variables_metadata[var] for var in variables if variables_metadata[var].is_model_level}
 
     lead_time_seconds = frequency_to_seconds(lead_time)
-    steps = list(map(lambda x: x // 3600, range(model_step, lead_time_seconds + model_step, model_step)))
+    steps = list(
+        map(
+            lambda x: x // 3600,
+            range(model_step, lead_time_seconds + model_step, model_step),
+        )
+    )
 
     def make_qubes(objs: list[dict[str, Sequence]], metadata: dict[str, Any]) -> Qube:
         if not objs:
@@ -219,7 +232,9 @@ def _expansion_qube(variables: list[str], variables_metadata: dict, model_step: 
     return pressure_qube | model_qube | surface_qube
 
 
-def parse_ensemble_members(ensemble_members: "ENSEMBLE_MEMBER_SPECIFICATION | None") -> list[int] | list[None]:
+def parse_ensemble_members(
+    ensemble_members: "ENSEMBLE_MEMBER_SPECIFICATION | None",
+) -> list[int] | list[None]:
     """Parse ensemble members"""
     if ensemble_members is None:
         return [None]
@@ -233,7 +248,7 @@ def parse_ensemble_members(ensemble_members: "ENSEMBLE_MEMBER_SPECIFICATION | No
 def expose_ensemble_dimension(x: dict, ens_mem: int | None) -> dict:
     assert isinstance(x, dict), "Input state must be a dictionary"
     if ens_mem is not None:
-        x["ensemble_member"] = ens_mem
+        x[ENSEMBLE_DIMENSION_NAME] = ens_mem
     return x
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,276 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Fixtures for integration tests.
+
+Provides a lightweight graph executor that traverses the DAG built by the
+fluent API and calls each payload's function, with anemoi-inference
+functions mocked so that no GPU or model weights are required.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import yaml
+from anemoi.inference.testing import fake_checkpoints
+from anemoi.inference.testing.mock_checkpoint import MockRunConfiguration
+from earthkit.workflows.fluent import Action, Payload
+from earthkit.workflows.graph import Node, Output
+
+from earthkit.workflows import serialise
+
+# ---------------------------------------------------------------------------
+# Helpers: resolve and execute payloads
+# ---------------------------------------------------------------------------
+
+
+def _resolve_func(func):
+    """Resolve a string function reference to a callable."""
+    if isinstance(func, str):
+        module_path, _, func_name = func.rpartition(".")
+        module = importlib.import_module(module_path)
+        return getattr(module, func_name)
+    return func
+
+
+def _make_fake_fieldlist(step: int, ensemble_member: int | None = None):
+    """Create a minimal fake fieldlist-like object for test outputs."""
+    fields = []
+    for param in ["2t", "10u", "10v", "msl", "tcc", "tp"]:
+        field = MagicMock()
+        field.metadata.return_value = {
+            "param": param,
+            "step": step,
+            "number": ensemble_member,
+        }
+        field.values = np.random.randn(100)
+        fields.append(field)
+
+    fieldlist = MagicMock()
+    fieldlist.fields = fields
+    fieldlist.__iter__ = lambda self: iter(fields)
+    fieldlist.__len__ = lambda self: len(fields)
+    return fieldlist
+
+
+def _make_fake_state(date: datetime.datetime, step_hours: int = 6) -> dict:
+    """Create a minimal fake anemoi state dict."""
+    return {
+        "date": date + datetime.timedelta(hours=step_hours),
+        "latitudes": np.linspace(-90, 90, 100),
+        "longitudes": np.linspace(0, 360, 100),
+        "fields": {
+            "2t": np.random.randn(100),
+            "10u": np.random.randn(100),
+            "10v": np.random.randn(100),
+            "msl": np.random.randn(100),
+            "tcc": np.random.randn(100),
+            "tp": np.random.randn(100),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mock implementations of anemoi inference functions
+# ---------------------------------------------------------------------------
+
+
+def mock_get_initial_conditions_from_config(config, date, ens_mem=None, **kwargs):
+    """Mock replacement for _get_initial_conditions_from_config."""
+    from earthkit.data.utils.dates import to_datetime
+
+    from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+    state = {
+        "date": to_datetime(date),
+        "latitudes": np.linspace(-90, 90, 100),
+        "longitudes": np.linspace(0, 360, 100),
+        "fields": {
+            "2t": np.random.randn(100),
+            "10u": np.random.randn(100),
+            "10v": np.random.randn(100),
+            "msl": np.random.randn(100),
+            "tcc": np.random.randn(100),
+            "tp": np.random.randn(100),
+        },
+    }
+    if ens_mem is not None:
+        state[ENSEMBLE_DIMENSION_NAME] = ens_mem
+    return state
+
+
+def mock_run_as_earthkit_from_config(input_state, config, lead_time, **kwargs):
+    """Mock replacement for run_as_earthkit_from_config.
+
+    Yields one fake fieldlist per 6h step up to lead_time.
+    """
+    from anemoi.utils.dates import frequency_to_seconds
+
+    from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+    lead_time_seconds = frequency_to_seconds(lead_time)
+    model_step = 6 * 3600  # 6h steps
+    ensemble_member = input_state.get(ENSEMBLE_DIMENSION_NAME, None)
+
+    for step_seconds in range(model_step, lead_time_seconds + model_step, model_step):
+        step_hours = step_seconds // 3600
+        yield _make_fake_fieldlist(step_hours, ensemble_member)
+
+
+# ---------------------------------------------------------------------------
+# Graph executor
+# ---------------------------------------------------------------------------
+
+
+class SimpleGraphExecutor:
+    """Execute a fluent Action's graph by topologically traversing nodes.
+
+    This is a minimal executor for integration testing. It resolves payload
+    functions, calls them with their arguments, and collects results.
+    Payloads whose functions are in the mock registry get replaced with mocks.
+    """
+
+    def __init__(self, mock_registry: dict[str, Any] | None = None):
+        self.mock_registry = mock_registry or {}
+        self.results: dict[str, Any] = {}
+
+    def execute(self, action: Action) -> dict[str, Any]:
+        """Execute all nodes in the action's graph."""
+        graph = action.graph()
+        serialised = serialise(graph)
+
+        # Topological order: sources first
+        ordered = list(graph.nodes(forwards=True))
+
+        for node in ordered:
+            self._execute_node(node, serialised)
+
+        return self.results
+
+    def _execute_node(self, node: Node, serialised: dict) -> Any:
+        if node.name in self.results:
+            return self.results[node.name]
+
+        # Resolve inputs
+        input_values = {}
+        for input_name, output in node.inputs.items():
+            parent = output.parent if isinstance(output, Output) else output
+            if parent.name not in self.results:
+                self._execute_node(parent, serialised)
+            input_values[input_name] = self.results[parent.name]
+
+        # Execute payload
+        payload = node.payload
+        if payload is None:
+            self.results[node.name] = None
+            return None
+
+        if isinstance(payload, Payload):
+            func = payload.func
+            func_key = func if isinstance(func, str) else getattr(func, "__qualname__", str(func))
+
+            # Check mock registry
+            if func_key in self.mock_registry:
+                func = self.mock_registry[func_key]
+            else:
+                func = _resolve_func(func)
+
+            # Build args, replacing Node.input_name references with actual values
+
+            args = []
+            for arg in payload.args:
+                if isinstance(arg, str) and arg.startswith("input"):
+                    # This is a reference to an input node
+                    matching = [v for k, v in input_values.items()]
+                    if matching:
+                        args.append(matching[0])
+                    else:
+                        args.append(arg)
+                else:
+                    args.append(arg)
+
+            kwargs = dict(payload.kwargs)
+
+            try:
+                result = func(*args, **kwargs)
+                # If it's a generator, consume it
+                if hasattr(result, "__next__"):
+                    result = list(result)
+            except Exception as e:
+                result = f"ERROR: {e}"
+
+            self.results[node.name] = result
+            return result
+        else:
+            # Raw callable payload
+            if callable(payload):
+                result = payload()
+            else:
+                result = payload
+            self.results[node.name] = result
+            return result
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_registry():
+    """Registry mapping function paths to their mock replacements."""
+    return {
+        "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config": mock_get_initial_conditions_from_config,
+        "earthkit.workflows.plugins.anemoi.inference.run_as_earthkit_from_config": mock_run_as_earthkit_from_config,
+    }
+
+
+@pytest.fixture
+def executor(mock_registry):
+    """A SimpleGraphExecutor wired up with mocks."""
+    return SimpleGraphExecutor(mock_registry)
+
+
+@pytest.fixture
+@fake_checkpoints
+def simple_ckpt_path():
+    return str((Path(__file__).parent.parent / "checkpoints" / "simple.yaml").absolute())
+
+
+@pytest.fixture
+@fake_checkpoints
+def full_atmo_ckpt_path():
+    return str((Path(__file__).parent.parent / "checkpoints" / "full_atmo.yaml").absolute())
+
+
+@pytest.fixture
+@fake_checkpoints
+def mock_config(tmp_path: Path):
+    parent_dir = Path(__file__).parent.parent
+    config_path = parent_dir / "configs" / "simple.yaml"
+
+    config_dict = yaml.safe_load(config_path.read_text())
+    config_dict["checkpoint"] = f"{parent_dir}/{config_dict['checkpoint']}"
+
+    with open(tmp_path / "simple.yaml", "w") as f:
+        yaml.safe_dump(config_dict, f)
+
+    tmp_path = tmp_path / "simple.yaml"
+
+    return MockRunConfiguration.load(
+        str(tmp_path.absolute()),
+        overrides=dict(runner="testing", device="cpu", input="dummy"),
+    )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,470 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Integration tests for the earthkit-workflows-anemoi plugin.
+
+These tests build full workflow DAGs and execute them through a lightweight
+graph executor with mocked anemoi-inference functions. They verify:
+
+1. DAG structure is correct (nodes, edges, dimensions)
+2. Payloads can be resolved and called
+3. Data flows correctly between initial conditions and inference
+4. Ensemble dimensions use the correct ENSEMBLE_DIMENSION_NAME constant
+5. Serialisation round-trips work
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+from anemoi.inference.testing import fake_checkpoints
+from earthkit.workflows.fluent import nodetree_arrays
+
+from earthkit.workflows import Cascade, Graph, serialise
+from earthkit.workflows.plugins.anemoi.fluent import Inference, from_initial_conditions, from_input
+from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_payloads(action):
+    """Collect all payload function references from an action's nodes."""
+    payloads = []
+    for _, narray in nodetree_arrays(action.nodes):
+        for node in np.atleast_1d(narray.values).flatten():
+            if hasattr(node, "payload") and node.payload is not None:
+                payloads.append(node.payload)
+    return payloads
+
+
+def collect_graph_payload_funcs(action):
+    """Collect all unique payload function paths from an action's full graph.
+
+    Uses graph.nodes() to get ALL nodes including intermediate ones
+    (not just the leaf nodes exposed by nodetree_arrays).
+    """
+    funcs = set()
+    graph = action.graph()
+    for node in graph.nodes():
+        p = node.payload
+        if p is not None and hasattr(p, "func"):
+            f = p.func
+            if isinstance(f, str):
+                funcs.add(f)
+    return funcs
+
+
+def collect_graph_payload_func_labels(action):
+    """Collect all payload function labels (strings or qualnames) from the full graph."""
+    labels = set()
+    graph = action.graph()
+    for node in graph.nodes():
+        p = node.payload
+        if p is not None and hasattr(p, "func"):
+            f = p.func
+            if isinstance(f, str):
+                labels.add(f)
+            elif hasattr(f, "__qualname__"):
+                labels.add(f.__qualname__)
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# DAG structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestDAGStructure:
+    """Verify the structure of DAGs built by the fluent API."""
+
+    @fake_checkpoints
+    def test_from_input_builds_valid_graph(self, simple_ckpt_path):
+        """from_input should produce a DAG that can be converted to a Graph."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+
+        assert isinstance(graph, Graph)
+        nodes = list(graph.nodes())
+        assert len(nodes) > 0
+
+    @fake_checkpoints
+    def test_from_input_graph_is_acyclic(self, simple_ckpt_path):
+        """The DAG must not contain cycles."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+        assert not graph.has_cycle()
+
+    @fake_checkpoints
+    def test_from_input_has_source_nodes(self, simple_ckpt_path):
+        """The graph should have source nodes (initial conditions)."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+        sources = list(graph.sources())
+        assert len(sources) > 0
+
+    @fake_checkpoints
+    def test_ensemble_dimension_in_graph(self, simple_ckpt_path):
+        """Ensemble runs should have the correct dimension name in coords."""
+        action = from_input(
+            simple_ckpt_path,
+            "dummy",
+            date="2020-01-01",
+            lead_time="1D",
+            ensemble_members=3,
+        )
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+        assert action.nodes.coords[ENSEMBLE_DIMENSION_NAME].size == 3
+
+    @fake_checkpoints
+    def test_single_member_has_ensemble_coord(self, simple_ckpt_path):
+        """A deterministic run should have the ensemble name as a scalar coordinate, not a dimension."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        # Single member: ensemble name appears as a scalar coordinate (value None),
+        # NOT as a dimension with size > 0
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.coords
+
+    @fake_checkpoints
+    def test_from_initial_conditions_builds_graph(self, simple_ckpt_path):
+        """from_initial_conditions with None should build a valid graph."""
+        action = from_initial_conditions(simple_ckpt_path, None, lead_time="1D")
+        graph = action.graph()
+        assert isinstance(graph, Graph)
+        assert not graph.has_cycle()
+
+    @fake_checkpoints
+    def test_inference_class_from_input(self, simple_ckpt_path):
+        """Inference class should produce identical structure to module function."""
+        inference = Inference(simple_ckpt_path, lead_time="1D")
+        action = inference.from_input("dummy", "2020-01-01", ensemble_members=2)
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+        assert action.nodes.coords[ENSEMBLE_DIMENSION_NAME].size == 2
+
+
+# ---------------------------------------------------------------------------
+# Payload resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadResolution:
+    """Verify payloads reference valid, resolvable functions."""
+
+    @fake_checkpoints
+    def test_from_input_payloads_are_resolvable(self, simple_ckpt_path):
+        """All string-referenced payloads should be importable."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        funcs = collect_graph_payload_funcs(action)
+
+        import importlib
+
+        for func_path in funcs:
+            module_path, _, func_name = func_path.rpartition(".")
+            module = importlib.import_module(module_path)
+            assert hasattr(module, func_name), f"Cannot resolve {func_path}"
+
+    @fake_checkpoints
+    def test_payloads_contain_expected_functions(self, simple_ckpt_path):
+        """The DAG should reference the expected inference functions."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        labels = collect_graph_payload_func_labels(action)
+
+        # Should have both IC fetch and model run
+        label_str = " ".join(labels)
+        assert "_get_initial_conditions_from_config" in label_str
+        assert "run_as_earthkit_from_config" in label_str
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerialisation:
+    """Verify graphs can be serialised and deserialised."""
+
+    @fake_checkpoints
+    def test_graph_serialises(self, simple_ckpt_path):
+        """The graph should serialise to a dict without errors."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+        data = serialise(graph)
+        assert isinstance(data, dict)
+        assert len(data) > 0
+
+    @fake_checkpoints
+    def test_cascade_from_actions(self, simple_ckpt_path):
+        """Should be able to create a Cascade object from actions."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        cascade = Cascade.from_actions([action])
+        assert cascade is not None
+
+    @fake_checkpoints
+    def test_cascade_serialise_round_trip(self, simple_ckpt_path, tmp_path):
+        """Cascade serialise -> deserialise should not error."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        cascade = Cascade.from_actions([action])
+
+        filepath = tmp_path / "test_cascade.pkl"
+        cascade.serialise(str(filepath))
+
+        loaded = Cascade.from_serialised(str(filepath))
+        assert loaded is not None
+
+
+# ---------------------------------------------------------------------------
+# Payload metadata propagation (integration level)
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadMetadataIntegration:
+    """Verify metadata flows through the full pipeline."""
+
+    @fake_checkpoints
+    def test_environment_metadata_on_anemoi_nodes(self, simple_ckpt_path):
+        """Anemoi payload nodes (string-referenced) should carry environment metadata."""
+        action = from_input(
+            simple_ckpt_path,
+            "dummy",
+            date="2020-01-01",
+            lead_time="1D",
+            environment=["anemoi-inference~=0.10"],
+        )
+        graph = action.graph()
+        anemoi_nodes_found = 0
+        for node in graph.nodes():
+            p = node.payload
+            if p is not None and hasattr(p, "func") and isinstance(p.func, str):
+                anemoi_nodes_found += 1
+                assert (
+                    "environment" in p.metadata
+                ), f"Node {node.name!r} with func {p.func!r} missing environment metadata"
+        assert anemoi_nodes_found > 0, "No anemoi payload nodes found in graph"
+
+    @fake_checkpoints
+    def test_custom_payload_metadata_survives_graph(self, simple_ckpt_path):
+        """Custom payload_metadata should be on every node after graph construction."""
+        custom = {"experiment_id": "test-001", "run_type": "integration"}
+        action = from_input(
+            simple_ckpt_path,
+            "dummy",
+            date="2020-01-01",
+            lead_time="1D",
+            payload_metadata=custom,
+        )
+        graph = action.graph()
+        serialised = serialise(graph)
+
+        # The metadata should survive serialisation
+        for node_name, node_data in serialised.items():
+            if "payload" in node_data:
+                payload = node_data["payload"]
+                if isinstance(payload, dict) and "metadata" in payload:
+                    for key in custom:
+                        assert key in payload["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# Execution tests (with mocked anemoi functions)
+# ---------------------------------------------------------------------------
+
+
+class TestExecution:
+    """Execute anemoi-specific payloads from the DAG with mocked inference functions.
+
+    These tests verify that the anemoi payload functions (IC fetch and model run)
+    can be resolved and called with correct arguments. Internal earthkit-workflows
+    operations (Backend.take etc.) are skipped as they need the full Cascade runtime.
+    """
+
+    @fake_checkpoints
+    def test_anemoi_payloads_callable(self, simple_ckpt_path, mock_registry):
+        """Verify the anemoi payload functions exist in mock registry and are callable."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+
+        anemoi_funcs_found = set()
+        for node in graph.nodes():
+            p = node.payload
+            if p is None or not hasattr(p, "func"):
+                continue
+            if not isinstance(p.func, str):
+                continue
+
+            func_path = p.func
+            anemoi_funcs_found.add(func_path)
+            # Verify the mock exists
+            assert func_path in mock_registry, f"No mock registered for {func_path}"
+            assert callable(mock_registry[func_path])
+
+        # Should have found at least the IC and model run functions
+        assert any("initial_conditions" in f for f in anemoi_funcs_found)
+        assert any("run_as_earthkit" in f for f in anemoi_funcs_found)
+
+    @fake_checkpoints
+    def test_ic_mock_returns_valid_state(self, simple_ckpt_path, mock_registry):
+        """The mocked IC function should return a dict with required keys."""
+        from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+        ic_func = mock_registry["earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config"]
+        state = ic_func(config={}, date="2020-01-01")
+        assert isinstance(state, dict)
+        assert "date" in state
+        assert "fields" in state
+        assert "latitudes" in state
+        assert "longitudes" in state
+        assert ENSEMBLE_DIMENSION_NAME not in state  # deterministic
+
+        state_ens = ic_func(config={}, date="2020-01-01", ens_mem=3)
+        assert ENSEMBLE_DIMENSION_NAME in state_ens
+        assert state_ens[ENSEMBLE_DIMENSION_NAME] == 3
+
+    @fake_checkpoints
+    def test_run_mock_yields_fieldlists(self, simple_ckpt_path, mock_registry):
+        """The mocked run function should yield fieldlist-like objects."""
+        import datetime
+
+        ic_func = mock_registry["earthkit.workflows.plugins.anemoi.inference._get_initial_conditions_from_config"]
+        run_func = mock_registry["earthkit.workflows.plugins.anemoi.inference.run_as_earthkit_from_config"]
+
+        state = ic_func(config={}, date="2020-01-01")
+        results = list(run_func(state, config={}, lead_time=datetime.timedelta(days=1)))
+        assert len(results) == 4  # 4 x 6h steps in 1D
+        for r in results:
+            assert hasattr(r, "fields")
+            assert len(r.fields) > 0
+
+
+# ---------------------------------------------------------------------------
+# Ensemble dimension consistency
+# ---------------------------------------------------------------------------
+
+
+class TestEnsembleDimensionConsistency:
+    """Verify ensemble dimension naming is consistent throughout the pipeline."""
+
+    @fake_checkpoints
+    def test_dimension_name_in_action_coords(self, simple_ckpt_path):
+        """The action's coords should use ENSEMBLE_DIMENSION_NAME, not 'ensemble_member'."""
+        action = from_input(
+            simple_ckpt_path,
+            "dummy",
+            date="2020-01-01",
+            lead_time="1D",
+            ensemble_members=3,
+        )
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.coords
+        assert ENSEMBLE_DIMENSION_NAME == "number"
+        if ENSEMBLE_DIMENSION_NAME != "ensemble_member":
+            assert "ensemble_member" not in action.nodes.dims
+
+    @fake_checkpoints
+    def test_dimension_name_in_payload_args(self, simple_ckpt_path):
+        """Payload dimension references should use the current constant value."""
+        action = from_input(
+            simple_ckpt_path,
+            "dummy",
+            date="2020-01-01",
+            lead_time="1D",
+            ensemble_members=3,
+        )
+        # Check that payloads reference the correct dimension name in their kwargs
+        for _, narray in nodetree_arrays(action.nodes):
+            for node in np.atleast_1d(narray.values).flatten():
+                if hasattr(node, "payload") and node.payload is not None:
+                    kwargs = node.payload.kwargs
+                    # If there's a dimension argument, it should match
+                    if "dim" in kwargs:
+                        dim_val = kwargs["dim"]
+                        if isinstance(dim_val, tuple) and len(dim_val) == 2:
+                            assert dim_val[0] == ENSEMBLE_DIMENSION_NAME
+
+    @fake_checkpoints
+    def test_from_initial_conditions_action_uses_correct_dim(self, simple_ckpt_path):
+        """from_initial_conditions with a pre-built action should match dimension name."""
+        from earthkit.workflows import fluent
+
+        init = fluent.from_source(
+            [None, None, None],
+            dims=[ENSEMBLE_DIMENSION_NAME],
+            coords={ENSEMBLE_DIMENSION_NAME: [1, 2, 3]},
+        )
+        action = from_initial_conditions(simple_ckpt_path, init, lead_time="1D")
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+
+    @fake_checkpoints
+    def test_expose_ensemble_dimension_in_mock_execution(self, simple_ckpt_path, executor):
+        """Verify the ensemble key in executed states uses the constant name."""
+        from earthkit.workflows.plugins.anemoi.utils import expose_ensemble_dimension
+
+        state = {"date": "2020-01-01"}
+        result = expose_ensemble_dimension(state, 5)
+        assert ENSEMBLE_DIMENSION_NAME in result
+        assert result[ENSEMBLE_DIMENSION_NAME] == 5
+
+
+# ---------------------------------------------------------------------------
+# Multi-checkpoint / multi-model tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiCheckpoint:
+    """Test with different checkpoint configurations."""
+
+    @fake_checkpoints
+    def test_full_atmo_checkpoint(self, full_atmo_ckpt_path):
+        """full_atmo checkpoint should produce a DAG with level dimensions."""
+        action = from_input(full_atmo_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+        assert not graph.has_cycle()
+
+        # full_atmo has pressure levels
+        shapes = defaultdict(set)
+        for _, narray in nodetree_arrays(action.nodes):
+            for dim, size in narray.coords.items():
+                shapes[dim].update(np.atleast_1d(size.values))
+        assert "level" in shapes
+
+    @fake_checkpoints
+    def test_full_atmo_with_ensemble(self, full_atmo_ckpt_path):
+        """full_atmo with ensemble should have both level and ensemble coords."""
+        action = from_input(
+            full_atmo_ckpt_path,
+            "dummy",
+            date="2020-01-01",
+            lead_time="1D",
+            ensemble_members=2,
+        )
+        # Collect all dims and coords from the tree (including children)
+        all_dims = set()
+        all_coords = set()
+        for _, narray in nodetree_arrays(action.nodes):
+            all_dims.update(narray.dims)
+            all_coords.update(narray.coords.keys())
+        assert ENSEMBLE_DIMENSION_NAME in all_dims
+        # level appears as a coordinate (possibly scalar) on pressure level groups
+        assert "level" in all_coords
+
+    @fake_checkpoints
+    def test_multiple_lead_times(self, simple_ckpt_path):
+        """Different lead times should produce different step counts."""
+        action_1d = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        action_4d = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="4D")
+
+        steps_1d = set()
+        steps_4d = set()
+        for _, narray in nodetree_arrays(action_1d.nodes):
+            if "step" in narray.coords:
+                steps_1d.update(np.atleast_1d(narray.coords["step"].values))
+        for _, narray in nodetree_arrays(action_4d.nodes):
+            if "step" in narray.coords:
+                steps_4d.update(np.atleast_1d(narray.coords["step"].values))
+
+        assert len(steps_4d) > len(steps_1d)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -22,6 +22,7 @@ graph executor with mocked anemoi-inference functions. They verify:
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -29,7 +30,14 @@ from anemoi.inference.testing import fake_checkpoints
 from earthkit.workflows.fluent import nodetree_arrays
 
 from earthkit.workflows import Cascade, Graph, serialise
-from earthkit.workflows.plugins.anemoi.fluent import Inference, from_initial_conditions, from_input
+from earthkit.workflows.plugins.anemoi.fluent import (
+    Action,
+    Inference,
+    from_config,
+    from_initial_conditions,
+    from_input,
+    get_initial_conditions,
+)
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
 
 pytestmark = pytest.mark.integration
@@ -471,3 +479,239 @@ class TestMultiCheckpoint:
                 steps_4d.update(np.atleast_1d(narray.coords["step"].values))
 
         assert len(steps_4d) > len(steps_1d)
+
+
+# ---------------------------------------------------------------------------
+# Data flow tests -- all entry points and chaining patterns
+# ---------------------------------------------------------------------------
+
+
+class TestDataFlows:
+    """Verify all entry point flows produce valid DAGs with correct structure."""
+
+    # --- from_config ---
+
+    @fake_checkpoints
+    def test_from_config_builds_graph(self, mock_config):
+        """from_config should build a valid acyclic graph."""
+        ckpt = str((Path(__file__).parent.parent / "checkpoints" / "simple.yaml").absolute())
+        action = from_config(
+            mock_config,
+            date="2020-01-01",
+            lead_time="1D",
+            checkpoint=ckpt,
+            input="dummy",
+        )
+        graph = action.graph()
+        assert isinstance(graph, Graph)
+        assert not graph.has_cycle()
+        assert len(list(graph.nodes())) > 0
+
+    @fake_checkpoints
+    def test_from_config_with_ensemble(self, mock_config):
+        """from_config with ensemble members should have the ensemble dimension."""
+        ckpt = str((Path(__file__).parent.parent / "checkpoints" / "simple.yaml").absolute())
+        action = from_config(
+            mock_config,
+            date="2020-01-01",
+            lead_time="1D",
+            checkpoint=ckpt,
+            input="dummy",
+            ensemble_members=3,
+        )
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+        assert action.nodes.coords[ENSEMBLE_DIMENSION_NAME].size == 3
+
+    @fake_checkpoints
+    def test_from_config_payloads_resolvable(self, mock_config):
+        """from_config graph payloads should be importable."""
+        ckpt = str((Path(__file__).parent.parent / "checkpoints" / "simple.yaml").absolute())
+        action = from_config(
+            mock_config,
+            date="2020-01-01",
+            lead_time="1D",
+            checkpoint=ckpt,
+            input="dummy",
+        )
+        funcs = collect_graph_payload_funcs(action)
+        assert len(funcs) > 0
+
+        import importlib
+
+        for func_path in funcs:
+            module_path, _, func_name = func_path.rpartition(".")
+            module = importlib.import_module(module_path)
+            assert hasattr(module, func_name), f"Cannot resolve {func_path}"
+
+    # --- get_initial_conditions (standalone IC fetch) ---
+
+    @fake_checkpoints
+    def test_get_initial_conditions_builds_graph(self, simple_ckpt_path):
+        """get_initial_conditions should produce a valid graph."""
+        action = get_initial_conditions(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+        assert isinstance(graph, Graph)
+        assert not graph.has_cycle()
+
+    @fake_checkpoints
+    def test_get_initial_conditions_has_ic_payload(self, simple_ckpt_path):
+        """get_initial_conditions graph should reference the IC fetch function."""
+        action = get_initial_conditions(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        assert "_get_initial_conditions_from_config" in label_str
+
+    @fake_checkpoints
+    def test_get_initial_conditions_no_run_payload(self, simple_ckpt_path):
+        """get_initial_conditions should NOT have a model run payload."""
+        action = get_initial_conditions(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        assert "run_as_earthkit_from_config" not in label_str
+
+    # --- Inference class: from_initial_conditions ---
+
+    @fake_checkpoints
+    def test_inference_from_initial_conditions_none(self, simple_ckpt_path):
+        """Inference.from_initial_conditions(None) should build a valid graph."""
+        inference = Inference(simple_ckpt_path, lead_time="1D")
+        action = inference.from_initial_conditions(None, ensemble_members=2)
+        graph = action.graph()
+        assert not graph.has_cycle()
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+
+    @fake_checkpoints
+    def test_inference_from_initial_conditions_action(self, simple_ckpt_path):
+        """Inference.from_initial_conditions with a fluent.Action should chain correctly."""
+        from earthkit.workflows import fluent
+
+        init = fluent.from_source(
+            [None, None],
+            dims=[ENSEMBLE_DIMENSION_NAME],
+            coords={ENSEMBLE_DIMENSION_NAME: [1, 2]},
+        )
+        inference = Inference(simple_ckpt_path, lead_time="1D")
+        action = inference.from_initial_conditions(init)
+
+        graph = action.graph()
+        assert not graph.has_cycle()
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+
+        # Should have the model run payload
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        assert "run_as_earthkit_from_config" in label_str
+
+    # --- Inference class: get_initial_conditions ---
+
+    @fake_checkpoints
+    def test_inference_get_initial_conditions(self, simple_ckpt_path):
+        """Inference.get_initial_conditions should produce IC-only graph."""
+        inference = Inference(simple_ckpt_path, lead_time="1D")
+        action = inference.get_initial_conditions("dummy", "2020-01-01")
+        graph = action.graph()
+        assert not graph.has_cycle()
+
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        assert "_get_initial_conditions_from_config" in label_str
+        assert "run_as_earthkit_from_config" not in label_str
+
+    # --- Action.infer chaining ---
+
+    @fake_checkpoints
+    def test_action_infer_chains_correctly(self, simple_ckpt_path):
+        """Action.infer should chain IC action into a full inference graph."""
+        from earthkit.workflows import fluent
+
+        init = Action(
+            fluent.from_source(
+                [None, None],
+                dims=[ENSEMBLE_DIMENSION_NAME],
+                coords={ENSEMBLE_DIMENSION_NAME: [1, 2]},
+            ).nodes
+        )
+        action = init.infer(simple_ckpt_path, lead_time="1D")
+        graph = action.graph()
+        assert not graph.has_cycle()
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+
+        # Should have model run payload since we chained inference
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        assert "run_as_earthkit_from_config" in label_str
+
+    # --- get_initial_conditions -> from_initial_conditions pipeline ---
+
+    @fake_checkpoints
+    def test_ic_to_inference_pipeline(self, simple_ckpt_path):
+        """get_initial_conditions output fed into from_initial_conditions should work."""
+        ic_action = get_initial_conditions(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        action = from_initial_conditions(simple_ckpt_path, ic_action, lead_time="1D")
+        graph = action.graph()
+        assert not graph.has_cycle()
+
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        # Should have both IC fetch and model run
+        assert "_get_initial_conditions_from_config" in label_str
+        assert "run_as_earthkit_from_config" in label_str
+
+    @fake_checkpoints
+    def test_ic_to_infer_pipeline_with_ensemble(self, simple_ckpt_path):
+        """get_initial_conditions -> Action.infer with ensemble should propagate dims."""
+        from earthkit.workflows import fluent
+
+        # Build ensemble IC source
+        init = Action(
+            fluent.from_source(
+                [None, None, None],
+                dims=[ENSEMBLE_DIMENSION_NAME],
+                coords={ENSEMBLE_DIMENSION_NAME: [1, 2, 3]},
+            ).nodes
+        )
+        action = init.infer(simple_ckpt_path, lead_time="1D")
+
+        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
+        assert action.nodes.coords[ENSEMBLE_DIMENSION_NAME].size == 3
+
+        graph = action.graph()
+        assert not graph.has_cycle()
+
+    # --- from_input includes both IC and run ---
+
+    @fake_checkpoints
+    def test_from_input_has_both_ic_and_run(self, simple_ckpt_path):
+        """from_input graph should contain both IC fetch and model run payloads."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        labels = collect_graph_payload_func_labels(action)
+        label_str = " ".join(labels)
+        assert "_get_initial_conditions_from_config" in label_str
+        assert "run_as_earthkit_from_config" in label_str
+
+    # --- from_initial_conditions with None vs Action produce different graphs ---
+
+    @fake_checkpoints
+    def test_from_initial_conditions_none_vs_action(self, simple_ckpt_path):
+        """from_initial_conditions(None) and from_initial_conditions(action) should
+        both produce valid graphs but with different source structures."""
+        from earthkit.workflows import fluent
+
+        action_none = from_initial_conditions(simple_ckpt_path, None, lead_time="1D", ensemble_members=2)
+        init = fluent.from_source(
+            [None, None],
+            dims=[ENSEMBLE_DIMENSION_NAME],
+            coords={ENSEMBLE_DIMENSION_NAME: [1, 2]},
+        )
+        action_from_act = from_initial_conditions(simple_ckpt_path, init, lead_time="1D")
+
+        graph_none = action_none.graph()
+        graph_act = action_from_act.graph()
+
+        assert not graph_none.has_cycle()
+        assert not graph_act.has_cycle()
+
+        # Both should have the model run payload
+        for action in [action_none, action_from_act]:
+            labels = collect_graph_payload_func_labels(action)
+            assert any("run_as_earthkit_from_config" in label for label in labels)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,12 +24,15 @@ from __future__ import annotations
 from collections import defaultdict
 
 import numpy as np
+import pytest
 from anemoi.inference.testing import fake_checkpoints
 from earthkit.workflows.fluent import nodetree_arrays
 
 from earthkit.workflows import Cascade, Graph, serialise
 from earthkit.workflows.plugins.anemoi.fluent import Inference, from_initial_conditions, from_input
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+pytestmark = pytest.mark.integration
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,56 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for the ENSEMBLE_DIMENSION_NAME constant and its consistent usage.
+
+The dimension name was changed from 'ensemble_member' to 'number' in commit
+7fd7969. These tests verify the value is correct and that it is used
+consistently across the codebase rather than hardcoded strings.
+"""
+
+from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
+
+def test_ensemble_dimension_name_value():
+    """ENSEMBLE_DIMENSION_NAME should be 'number'."""
+    assert ENSEMBLE_DIMENSION_NAME == "number"
+
+
+def test_ensemble_dimension_name_is_string():
+    """ENSEMBLE_DIMENSION_NAME should be a str."""
+    assert isinstance(ENSEMBLE_DIMENSION_NAME, str)
+
+
+def test_ensemble_dimension_name_reexported_from_init():
+    """The constant should be re-exported from the package __init__."""
+    from earthkit.workflows.plugins.anemoi import ENSEMBLE_DIMENSION_NAME as reexported
+
+    assert reexported == "number"
+
+
+def test_expose_ensemble_dimension_uses_constant():
+    """expose_ensemble_dimension should use ENSEMBLE_DIMENSION_NAME, not a hardcoded key."""
+    from earthkit.workflows.plugins.anemoi.utils import expose_ensemble_dimension
+
+    state = {"date": "2020-01-01"}
+    result = expose_ensemble_dimension(state, 3)
+    assert ENSEMBLE_DIMENSION_NAME in result
+    assert result[ENSEMBLE_DIMENSION_NAME] == 3
+    # Must NOT use the old hardcoded key
+    if ENSEMBLE_DIMENSION_NAME != "ensemble_member":
+        assert "ensemble_member" not in result
+
+
+def test_expose_ensemble_dimension_none_member():
+    """When ens_mem is None, no ensemble key should be added."""
+    from earthkit.workflows.plugins.anemoi.utils import expose_ensemble_dimension
+
+    state = {"date": "2020-01-01"}
+    result = expose_ensemble_dimension(state, None)
+    assert ENSEMBLE_DIMENSION_NAME not in result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,279 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for earthkit.workflows.plugins.anemoi.utils."""
+
+from pathlib import Path
+
+import pytest
+from anemoi.inference.testing import fake_checkpoints
+
+from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+from earthkit.workflows.plugins.anemoi.utils import (
+    _add_self_to_environment,
+    crack_environment,
+    expansion_qube_from_metadata,
+    expansion_qube_from_variables,
+    expose_ensemble_dimension,
+    faked_ensemble_transform,
+    parse_ensemble_members,
+)
+
+# --- parse_ensemble_members ---
+
+
+class TestParseEnsembleMembers:
+    """Tests for parse_ensemble_members."""
+
+    def test_none_returns_list_of_none(self):
+        assert parse_ensemble_members(None) == [None]
+
+    def test_single_int(self):
+        result = parse_ensemble_members(3)
+        assert result == [1, 2, 3]
+
+    def test_single_int_one(self):
+        result = parse_ensemble_members(1)
+        assert result == [1]
+
+    def test_sequence_passed_through(self):
+        result = parse_ensemble_members([5, 10, 15])
+        assert result == [5, 10, 15]
+
+    def test_range_passed_through(self):
+        result = parse_ensemble_members(range(1, 4))
+        assert result == [1, 2, 3]
+
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="greater than 0"):
+            parse_ensemble_members(0)
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="greater than 0"):
+            parse_ensemble_members(-1)
+
+
+# --- expose_ensemble_dimension ---
+
+
+class TestExposeEnsembleDimension:
+    """Tests for expose_ensemble_dimension."""
+
+    def test_adds_ensemble_key(self):
+        state = {"date": "2020-01-01"}
+        result = expose_ensemble_dimension(state, 5)
+        assert result[ENSEMBLE_DIMENSION_NAME] == 5
+
+    def test_none_member_no_key(self):
+        state = {"date": "2020-01-01"}
+        result = expose_ensemble_dimension(state, None)
+        assert ENSEMBLE_DIMENSION_NAME not in result
+
+    def test_mutates_input_dict(self):
+        """The function should mutate the dict in place and return it."""
+        state = {"date": "2020-01-01"}
+        result = expose_ensemble_dimension(state, 1)
+        assert result is state
+
+    def test_non_dict_raises(self):
+        with pytest.raises(AssertionError, match="dictionary"):
+            expose_ensemble_dimension("not a dict", 1)
+
+    def test_uses_constant_not_hardcoded(self):
+        """Ensure the function uses the ENSEMBLE_DIMENSION_NAME constant."""
+        state = {}
+        expose_ensemble_dimension(state, 42)
+        assert ENSEMBLE_DIMENSION_NAME in state
+        # If the constant were still 'ensemble_member', this would trivially pass.
+        # The important test is that only ENSEMBLE_DIMENSION_NAME is set.
+        assert len([k for k in state if k in ("ensemble_member", "number")]) == 1
+
+
+# --- faked_ensemble_transform ---
+
+
+class TestFakedEnsembleTransform:
+    """Tests for faked_ensemble_transform."""
+
+    def test_returns_action(self):
+        from earthkit.workflows import fluent
+
+        source = fluent.from_source([None], dims=["date"])
+        result = faked_ensemble_transform(source, ens_num=1)
+        assert isinstance(result, fluent.Action)
+
+    def test_with_none_ens_num(self):
+        from earthkit.workflows import fluent
+
+        source = fluent.from_source([None], dims=["date"])
+        result = faked_ensemble_transform(source, ens_num=None)
+        assert isinstance(result, fluent.Action)
+
+
+# --- _add_self_to_environment ---
+
+
+class TestAddSelfToEnvironment:
+    """Tests for _add_self_to_environment."""
+
+    def test_dev_version_unchanged(self):
+        """Development versions should not be added."""
+        import earthkit.workflows.plugins.anemoi as pkg
+
+        original = pkg.__version__
+        pkg.__version__ = "0.3.1.dev0"
+        try:
+            env = ["anemoi-inference~=0.10"]
+            result = _add_self_to_environment(env)
+            assert result == ["anemoi-inference~=0.10"]
+        finally:
+            pkg.__version__ = original
+
+    def test_empty_list_stays_empty(self):
+        """Empty environment lists should remain empty."""
+        result = _add_self_to_environment([])
+        assert result == []
+
+    def test_adds_self_to_list(self):
+        """Should append self to a non-empty list."""
+        import earthkit.workflows.plugins.anemoi as pkg
+
+        original = pkg.__version__
+        pkg.__version__ = "1.2.3"
+        try:
+            env = ["anemoi-inference~=0.10"]
+            result = _add_self_to_environment(env)
+            assert "earthkit-workflows-anemoi~=1.2.3" in result
+        finally:
+            pkg.__version__ = original
+
+    def test_no_duplicate(self):
+        """Should not add if already present."""
+        env = ["earthkit-workflows-anemoi~=1.0.0"]
+        result = _add_self_to_environment(env)
+        assert sum(1 for e in result if e.startswith("earthkit-workflows-anemoi")) == 1
+
+    def test_dict_environment(self):
+        """Should handle dict environments."""
+        import earthkit.workflows.plugins.anemoi as pkg
+
+        original = pkg.__version__
+        pkg.__version__ = "1.2.3"
+        try:
+            env = {"inference": ["anemoi-inference~=0.10"], "dataset": []}
+            result = _add_self_to_environment(env)
+            assert "earthkit-workflows-anemoi~=1.2.3" in result["inference"]
+            assert result["dataset"] == []
+        finally:
+            pkg.__version__ = original
+
+
+# --- crack_environment ---
+
+
+class TestCrackEnvironment:
+    """Tests for crack_environment."""
+
+    def test_none_environment(self):
+        result = crack_environment(None, ["inference", "dataset"])
+        assert "inference" in result
+        assert "dataset" in result
+
+    def test_list_environment(self):
+        env = ["anemoi-inference~=0.10"]
+        result = crack_environment(env, ["inference", "dataset"])
+        assert result["inference"] == result["dataset"]
+
+    def test_dict_environment(self):
+        env = {"inference": ["pkg1"], "dataset": ["pkg2"]}
+        result = crack_environment(env, ["inference", "dataset"])
+        assert "pkg1" in result["inference"]
+        assert "pkg2" in result["dataset"]
+
+    def test_dict_missing_key(self):
+        env = {"inference": ["pkg1"]}
+        result = crack_environment(env, ["inference", "dataset"])
+        assert "pkg1" in result["inference"]
+        assert isinstance(result["dataset"], list)
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="Invalid type"):
+            crack_environment(42, ["inference"])
+
+
+# --- expansion_qube_from_variables ---
+
+
+class TestExpansionQubeFromVariables:
+    """Tests for expansion_qube_from_variables."""
+
+    @fake_checkpoints
+    def test_basic(self):
+        """Build a qube from variables extracted from a checkpoint."""
+        from anemoi.inference.checkpoint import Checkpoint
+
+        ckpt_path = Path(__file__).parent / "checkpoints" / "simple.yaml"
+        ckpt = Checkpoint(ckpt_path)
+
+        variables = ckpt._metadata.select_variables(include=["diagnostic", "prognostic"], has_mars_requests=False)
+        variables_metadata = ckpt._metadata.typed_variables
+        model_step = ckpt._metadata.timestep.seconds
+
+        qube = expansion_qube_from_variables(variables, variables_metadata, model_step, "1D")
+        axes = qube.axes()
+        assert "step" in axes
+        assert "param" in axes
+
+    @fake_checkpoints
+    def test_matches_metadata_version(self):
+        """expansion_qube_from_variables should produce same result as expansion_qube_from_metadata."""
+        from anemoi.inference.checkpoint import Checkpoint
+
+        ckpt_path = Path(__file__).parent / "checkpoints" / "simple.yaml"
+        ckpt = Checkpoint(ckpt_path)
+        metadata = ckpt._metadata
+
+        variables = ckpt._metadata.select_variables(include=["diagnostic", "prognostic"], has_mars_requests=False)
+        variables_metadata = ckpt._metadata.typed_variables
+        model_step = ckpt._metadata.timestep.seconds
+
+        qube_from_vars = expansion_qube_from_variables(variables, variables_metadata, model_step, "1D")
+        qube_from_meta = expansion_qube_from_metadata(metadata, "1D")
+
+        assert qube_from_vars.axes() == qube_from_meta.axes()
+
+
+# --- expansion_qube_from_metadata with different lead times ---
+
+
+class TestExpansionQubeLeadTimes:
+    """Test expansion_qube_from_metadata with various lead time formats."""
+
+    @fake_checkpoints
+    def test_string_lead_time(self):
+        from anemoi.inference.checkpoint import Checkpoint
+
+        ckpt_path = Path(__file__).parent / "checkpoints" / "simple.yaml"
+        metadata = Checkpoint(ckpt_path)._metadata
+        qube = expansion_qube_from_metadata(metadata, "2D")
+        steps = qube.axes()["step"]
+        assert max(steps) == 48
+
+    @fake_checkpoints
+    def test_full_atmo_checkpoint(self):
+        """Test with full_atmo checkpoint that has pressure levels."""
+        from anemoi.inference.checkpoint import Checkpoint
+
+        ckpt_path = Path(__file__).parent / "checkpoints" / "full_atmo.yaml"
+        metadata = Checkpoint(ckpt_path)._metadata
+        qube = expansion_qube_from_metadata(metadata, "1D")
+        axes = qube.axes()
+        assert "level" in axes
+        assert "levtype" in axes
+        assert "pl" in axes["levtype"]


### PR DESCRIPTION
## Summary

- **Fix**: `expose_ensemble_dimension`, `_get_initial_conditions_ens`, and `run_as_earthkit` used the hardcoded string `"ensemble_member"` for state dict keys instead of the `ENSEMBLE_DIMENSION_NAME` constant (now `"number"` after 7fd7969). This caused inconsistent dimension naming at runtime.
- **Tests**: Expand test suite from 73 to 130 tests across three new test files and a new `tests/integration/` directory.
- **CI**: Split the `checks` job into `unit-tests` and `integration-tests`, both running across Python 3.11-3.13.

## New test files

| File | Tests | Coverage |
|------|-------|----------|
| `tests/test_types.py` | 5 | `ENSEMBLE_DIMENSION_NAME` value, re-export, and consistent usage |
| `tests/test_utils.py` | 28 | `parse_ensemble_members`, `expose_ensemble_dimension`, `faked_ensemble_transform`, `_add_self_to_environment`, `crack_environment`, `expansion_qube_from_variables`, lead time handling |
| `tests/integration/` | 24 | DAG structure, payload resolution, serialisation round-trips, metadata propagation, ensemble dimension consistency, multi-checkpoint, mock execution |

## Integration test approach

Integration tests build full workflow DAGs via the fluent API and verify:
1. Graph structure (acyclicity, source nodes, node counts)
2. Payload functions are resolvable and present in a mock registry
3. Cascade serialisation round-trips work
4. Environment and custom metadata propagate to anemoi payload nodes
5. Ensemble dimension naming is consistent throughout the pipeline
6. Mocked IC and model-run functions return valid outputs

Anemoi-inference functions are mocked so no GPU or model weights are needed.