### PR TITLE
fix: Inference seperate input call

### DIFF
--- a/docs/usage/inference.rst
+++ b/docs/usage/inference.rst
@@ -49,3 +49,38 @@ This will use the existing source nodes as the initial conditions, and
 run the inference task with the specified checkpoint, lead time. If the
 source nodes have an ensemble dimension, it will also run the inference
 task for each ensemble member.
+
+****************************
+ Getting Initial Conditions
+****************************
+
+If you need to retrieve the initial conditions separately — for example,
+to inspect them, share them across multiple models, or compose a custom
+workflow — use the
+:func:`~earthkit.workflows.plugins.anemoi.fluent.get_initial_conditions`
+function:
+
+.. code:: python
+
+   from earthkit.workflows.plugins.anemoi import fluent as anemoi_fluent
+
+   CKPT = {"huggingface": "ecmwf/aifs-single-1.0"}
+
+   ic = anemoi_fluent.get_initial_conditions(
+       CKPT,
+       "mars",
+       date="2022-01-01T00:00",
+   )
+
+This returns a :class:`~earthkit.workflows.fluent.Action` representing
+the initial state. You can then feed it into an inference run:
+
+.. code:: python
+
+   inference = anemoi_fluent.Inference(CKPT, lead_time="7D")
+   forecast = inference.from_initial_conditions(ic)
+
+This two-step approach is equivalent to using
+:func:`~earthkit.workflows.plugins.anemoi.fluent.from_input`, but gives
+you explicit access to the initial conditions action before inference
+begins.

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -235,7 +235,7 @@ class Inference:
         self.kwargs = kwargs
 
     def _config(self, **kwargs: Any) -> dict[str, Any]:
-        if set(*kwargs.keys()) & {"checkpoint", *self.kwargs.keys()}:
+        if set(kwargs.keys()) & {"checkpoint", *self.kwargs.keys()}:
             raise ValueError(
                 f"Cannot override checkpoint or keys set in the constructor: {set(kwargs.keys()) & {'checkpoint', *self.kwargs.keys()}}"
             )
@@ -469,7 +469,10 @@ def from_config(
     )
 
     return _run_model(
-        expansion_qube_from_metadata(_get_metadata(configuration.checkpoint), as_timedelta(configuration.lead_time)),  # type: ignore
+        expansion_qube_from_metadata(
+            _get_metadata(configuration.checkpoint),
+            as_timedelta(configuration.lead_time),
+        ),  # type: ignore
         configuration,
         input_state_source,
         configuration.lead_time,
@@ -604,35 +607,75 @@ def get_initial_conditions(
     **kwargs: Any,
 ) -> fluent.Action:
     """
-    Get initial conditions for an anemoi inference model
+    Get initial conditions for an anemoi inference model.
+
+    Retrieves the initial conditions (model state) needed to start an
+    ``anemoi-inference`` run, without performing the inference itself.
+    This is useful when you want to obtain the initial state separately,
+    for example to inspect it, pass it to multiple models, or use it as
+    input to a custom workflow.
+
+    The checkpoint is used to determine which variables and grid the
+    initial conditions should contain. The ``input`` parameter specifies
+    the data source (e.g. ``"mars"``, ``"grib"``, or a dictionary of
+    input configuration), matching the input sources supported by
+    ``anemoi-inference``.
 
     Parameters
     ----------
     ckpt : VALID_CKPT
-        Checkpoint to load
+        Checkpoint to load. Can be a path to a checkpoint file, a string,
+        or a dictionary (e.g. ``{"huggingface": "ecmwf/aifs-single-1.0"}``).
     input : str | dict[str, Any]
-        Input data for the model
+        ``anemoi-inference`` input source.
+        Can be ``"mars"``, ``"grib"``, etc. or a dictionary of input
+        configuration, following the same conventions as
+        ``anemoi-inference``.
     date : DATE
-        Date for the initial conditions
-    environment : Optional[list[str]], optional
-        Environment to run the model in, by default None
-        If None, will use the current environment
+        Date for the initial conditions. Can be a ``datetime.datetime``,
+        an ISO 8601 string (e.g. ``"2021-01-01T00:00:00"``), or a
+        ``(year, month, day)`` tuple.
+    environment : ENVIRONMENT, optional
+        Environment to run the initial conditions retrieval in, by default None.
+        If None, will use the current environment.
         Should be set to strings, as if used in pip install,
-        e.g. `["anemoi-models==0.3.1"]`
-    kwargs : dict
-        Additional arguments to pass to the configuration
+        e.g. ``["anemoi-models==0.3.1"]``.
+        Can be ``dict[str, list[str]]`` with the key ``"initial_conditions"``
+        to set the environment for the retrieval.
+    **kwargs : dict
+        Additional arguments to pass to the run configuration
+        (e.g. extra input overrides).
 
     Returns
     -------
     fluent.Action
-        earthkit.workflows action of the initial conditions
+        An ``earthkit.workflows`` action representing the initial
+        conditions. This action can be passed to
+        :meth:`Inference.from_initial_conditions` or used independently.
 
     Examples
     --------
+    Retrieve initial conditions from MARS:
+
     >>> from earthkit.workflows.plugins.anemoi.fluent import get_initial_conditions
-    >>> get_initial_conditions("anemoi_model.ckpt", "input_data", date = "2021-01-01T00:00:00")
+    >>> ic = get_initial_conditions("anemoi_model.ckpt", "mars", date="2021-01-01T00:00:00")
+
+    Use the initial conditions in a subsequent inference run:
+
+    >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
+    >>> inference = Inference("anemoi_model.ckpt", lead_time="10D")
+    >>> forecast = inference.from_initial_conditions(ic)
+
+    Use a HuggingFace checkpoint with a dictionary input configuration:
+
+    >>> ic = get_initial_conditions(
+    ...     {"huggingface": "ecmwf/aifs-single-1.0"},
+    ...     {"source": "mars", "class": "od"},
+    ...     date="2022-06-15T12:00:00",
+    ... )
     """
     config = {"checkpoint": ckpt, "input": input, **kwargs}
+
     environment_dict = crack_environment(environment, ["initial_conditions"])
     return _get_initial_conditions_source(
         config=config,
@@ -717,12 +760,17 @@ def create_dataset(
         number_of_tasks = len(groups) * 25
 
     path = os.path.abspath(path)
-    options = {"config": config_path, "path": path, "overwrite": overwrite, "test": test}
+    options = {
+        "config": config_path,
+        "path": path,
+        "overwrite": overwrite,
+        "test": test,
+    }
     payload_metadata = {"environment": environment or []}
 
     def get_parallel_options(part: int):
         opt = options.copy()
-        opt["parts"] = f"{part+1}/{number_of_tasks}"
+        opt["parts"] = f"{part + 1}/{number_of_tasks}"
         return opt
 
     def get_task(name: str, opt: dict[str, Any]) -> Callable[..., Any]:
@@ -878,7 +926,9 @@ def from_dataset(
     def construct_configuration(dataset_location: str):
         """Create configuration from dataset location"""
 
-        def insert_dataset_path(template: dict[str, Any] | list[str] | str) -> dict | list | str:
+        def insert_dataset_path(
+            template: dict[str, Any] | list[str] | str,
+        ) -> dict | list | str:
             """Insert the dataset path into the template"""
             if isinstance(template, dict):
                 return {k: insert_dataset_path(v) for k, v in template.items()}

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -389,6 +389,7 @@ class Inference:
             payload_metadata={"environment": environment_dict["inference"]},
         )
 
+    @capture_payload_metadata
     def get_initial_conditions(self, input: str | dict[str, Any], date: DATE, **kwargs: Any) -> fluent.Action:
         """
         Get initial conditions for an anemoi inference model.

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -389,39 +389,6 @@ class Inference:
             payload_metadata={"environment": environment_dict["inference"]},
         )
 
-    @capture_payload_metadata
-    def get_initial_conditions(self, input: str | dict[str, Any], date: DATE, **kwargs: Any) -> fluent.Action:
-        """
-        Get initial conditions for an anemoi inference model.
-
-        Parameters
-        ----------
-        input : str | dict[str, Any]
-            Input data for the model
-        date : DATE
-            Date for the initial conditions
-        kwargs : dict
-            Additional arguments to pass to the runner configuration
-
-        Returns
-        -------
-        fluent.Action
-            earthkit.workflows action of the initial conditions
-
-        Examples
-        --------
-        >>> from earthkit.workflows.plugins.anemoi.fluent import Inference
-        >>> inference = Inference("anemoi_model.ckpt", lead_time = "10D")
-        >>> inference.get_initial_conditions("mars", date = "2021-01-01T00:00:00")
-        """
-        config = self._config(input=input, **kwargs)
-        environment_dict = crack_environment(self.environment, ["initial_conditions"])
-        return _get_initial_conditions_source(
-            config=config,
-            date=date,
-            payload_metadata={"environment": environment_dict["initial_conditions"]},
-        )
-
 
 @capture_payload_metadata
 def from_config(
@@ -634,7 +601,6 @@ def get_initial_conditions(
     date: DATE,
     *,
     environment: ENVIRONMENT | None = None,
-    metadata: Metadata | None = None,
     **kwargs: Any,
 ) -> fluent.Action:
     """
@@ -653,8 +619,6 @@ def get_initial_conditions(
         If None, will use the current environment
         Should be set to strings, as if used in pip install,
         e.g. `["anemoi-models==0.3.1"]`
-    metadata : Optional[Metadata], optional
-        `anemoi.inference` metadata, if not given will be got from the checkpoint on disk, by default None
     kwargs : dict
         Additional arguments to pass to the configuration
 
@@ -668,9 +632,12 @@ def get_initial_conditions(
     >>> from earthkit.workflows.plugins.anemoi.fluent import get_initial_conditions
     >>> get_initial_conditions("anemoi_model.ckpt", "input_data", date = "2021-01-01T00:00:00")
     """
-    return Inference(ckpt, environment=environment, metadata=metadata, **kwargs).get_initial_conditions(
-        input,
-        date,
+    config = {"checkpoint": ckpt, "input": input, **kwargs}
+    environment_dict = crack_environment(environment, ["initial_conditions"])
+    return _get_initial_conditions_source(
+        config=config,
+        date=date,
+        payload_metadata={"environment": environment_dict["initial_conditions"]},
     )
 
 

--- a/src/earthkit/workflows/plugins/anemoi/runner.py
+++ b/src/earthkit/workflows/plugins/anemoi/runner.py
@@ -18,7 +18,7 @@ import logging
 import os
 
 from anemoi.inference.config.run import RunConfiguration
-from anemoi.inference.forcings import ComputedForcings, CoupledForcings, Forcings
+from anemoi.inference.forcings import ComputedForcings, Forcings
 from anemoi.inference.inputs import create_input
 from anemoi.inference.inputs.ekd import EkdInput
 from anemoi.inference.post_processors import create_post_processor
@@ -61,7 +61,7 @@ class CascadeRunner(Runner):
         Input
             The created input.
         """
-        variables = self.variables.retrieved_prognostic_variables()
+        variables = self.variables.default_input_variables()
         input = create_input(self, self.config.input, variables=variables)  # type: ignore # Error in anemoi.inference
         return input
 
@@ -118,11 +118,11 @@ class CascadeRunner(Runner):
         List
             The created constant coupled forcings.
         """
-        variables = self.variables.retrieved_constant_forcings_variables()
-        input = create_input(self, self.config.input, variables=variables)  # type: ignore # Error in anemoi.inference
-        result = CoupledForcings(self, input, variables, mask)
-        LOG.debug("Constant coupled forcing: %s", result)
-        return [result]
+        # This runner does not support coupled forcings
+        # there are supposed to be already in the state dictionary
+        # or managed by the user.
+        LOG.warning("Coupled forcings are not supported by this runner: %s", variables)
+        return []
 
     def create_dynamic_coupled_forcings(self, variables: list[str], mask: IntArray) -> list[Forcings]:
         """Create dynamic coupled forcings.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -602,21 +602,6 @@ class TestDataFlows:
         label_str = " ".join(labels)
         assert "run_as_earthkit_from_config" in label_str
 
-    # --- Inference class: get_initial_conditions ---
-
-    @fake_checkpoints
-    def test_inference_get_initial_conditions(self, simple_ckpt_path):
-        """Inference.get_initial_conditions should produce IC-only graph."""
-        inference = Inference(simple_ckpt_path, lead_time="1D")
-        action = inference.get_initial_conditions("dummy", "2020-01-01")
-        graph = action.graph()
-        assert not graph.has_cycle()
-
-        labels = collect_graph_payload_func_labels(action)
-        label_str = " ".join(labels)
-        assert "_get_initial_conditions_from_config" in label_str
-        assert "run_as_earthkit_from_config" not in label_str
-
     # --- Action.infer chaining ---
 
     @fake_checkpoints


### PR DESCRIPTION
### Description
This pull request refactors how initial conditions are retrieved for the Anemoi inference model in `fluent.py`. The main change is the removal of the `get_initial_conditions` method from the `Inference` class, consolidating and simplifying the logic into the standalone `get_initial_conditions` function. This reduces redundancy and streamlines the interface for obtaining initial conditions.

### Refactoring and Simplification

* Removed the `Inference.get_initial_conditions` method, eliminating duplicated logic and moving its responsibilities to the standalone `get_initial_conditions` function.
* Updated the `get_initial_conditions` function to directly construct the configuration and call `_get_initial_conditions_source`, rather than instantiating `Inference` and calling its method.

### API and Documentation Cleanup

* Removed the `metadata` parameter from the `get_initial_conditions` function signature and its docstring, as it is no longer needed. [[1]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL636) [[2]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL655-L656)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- readthedocs-preview earthkit-workflows-anemoi start -->
----
📚 Documentation preview 📚: https://earthkit-workflows-anemoi--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview earthkit-workflows-anemoi end -->