### PR TITLE
fix: missing needs_gpu flag in metadata

### DIFF
--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -186,7 +186,7 @@ def _run_model(
         "earthkit.workflows.plugins.anemoi.inference.run_as_earthkit_from_config",
         args=(fluent.Node.input_name(0),),
         kwargs=dict(config=config, lead_time=as_timedelta(lead_time), **kwargs),
-        metadata=payload_metadata,
+        metadata=dict(**(payload_metadata or {}), needs_gpu=True),
     )
 
     model_results = input_state_source.map(model_payload, yields=("step", list(expansion_qube.axes()["step"])))

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -281,6 +281,27 @@ class TestPayloadMetadataIntegration:
                     for key in custom:
                         assert key in payload["metadata"]
 
+    @fake_checkpoints
+    def test_run_as_earthkit_from_config_has_needs_gpu(self, simple_ckpt_path):
+        """The run_as_earthkit_from_config payload should have needs_gpu=True in metadata."""
+        action = from_input(simple_ckpt_path, "dummy", date="2020-01-01", lead_time="1D")
+        graph = action.graph()
+        model_nodes_found = 0
+        for node in graph.nodes():
+            p = node.payload
+            if (
+                p is not None
+                and hasattr(p, "func")
+                and isinstance(p.func, str)
+                and "run_as_earthkit_from_config" in p.func
+            ):
+                model_nodes_found += 1
+                assert p.metadata.get("needs_gpu") is True, (
+                    f"Node {node.name!r} with func {p.func!r} should have needs_gpu=True "
+                    f"in metadata, got {p.metadata}"
+                )
+        assert model_nodes_found > 0, "No run_as_earthkit_from_config nodes found in graph"
+
 
 # ---------------------------------------------------------------------------
 # Execution tests (with mocked anemoi functions)


### PR DESCRIPTION
### Description
Add the `needs_gpu` flag to the metadata in the `run_as_earthkit_from_config` function to ensure proper GPU requirements are communicated. Include a test to verify that the flag is set correctly in the payload metadata.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.

