### PR TITLE
fix: Double exposure of ens dim when stacking get and run calls

### DIFF
--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -153,8 +153,6 @@ def _get_initial_conditions_source(
         list(zip(ens_members)),
         (ENSEMBLE_DIMENSION_NAME, ens_members),  # type: ignore
     )
-    if ENSEMBLE_DIMENSION_NAME not in expanded_init.nodes.coords:
-        expanded_init.nodes = expanded_init.nodes.expand_dims(ENSEMBLE_DIMENSION_NAME)
     return expanded_init
 
 
@@ -404,29 +402,9 @@ class Inference:
                 dims=["date"],
             )  # type: ignore
 
-        if ENSEMBLE_DIMENSION_NAME in initial_conditions_source.nodes.dims:
-            if ensemble_members is None:
-                ensemble_members = len(initial_conditions_source.nodes.coords[ENSEMBLE_DIMENSION_NAME])
-
-            parsed_ensemble_members = parse_ensemble_members(ensemble_members)
-
-            if len(initial_conditions_source.nodes.coords[ENSEMBLE_DIMENSION_NAME]) != len(parsed_ensemble_members):
-                raise ValueError(
-                    "Number of ensemble members in initial conditions must match `ensemble_members` argument"
-                )
-            ens_initial_conditions = initial_conditions_source
-
-        else:
-            parsed_ensemble_members = parse_ensemble_members(ensemble_members)
-            ens_initial_conditions = initial_conditions_source.transform(
-                faked_ensemble_transform,
-                list(zip(parsed_ensemble_members)),  # type: ignore
-                (ENSEMBLE_DIMENSION_NAME, parsed_ensemble_members),  # type: ignore
-            )
-
         return self._run_model(
             config,
-            ens_initial_conditions,
+            initial_conditions_source,
             payload_metadata={"environment": environment_dict["inference"]},
         )
 

--- a/src/earthkit/workflows/plugins/anemoi/fluent.py
+++ b/src/earthkit/workflows/plugins/anemoi/fluent.py
@@ -28,7 +28,7 @@ from qubed import Qube
 from earthkit.workflows import fluent
 
 from .types import ENSEMBLE_DIMENSION_NAME
-from .utils import crack_environment, expansion_qube_from_metadata, faked_ensemble_transform, parse_ensemble_members
+from .utils import crack_environment, expansion_qube_from_metadata, parse_ensemble_members
 
 if TYPE_CHECKING:
     # anemoi-inference imports
@@ -58,7 +58,6 @@ def _get_initial_conditions_source(
     date: DATE,
     ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
     *,
-    initial_condition_perturbation: bool = False,
     payload_metadata: dict[str, Any] | None = None,
 ) -> fluent.Action:
     """
@@ -73,10 +72,6 @@ def _get_initial_conditions_source(
         Date to get initial conditions for
     ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
         Number of ensemble members to get, by default None
-    initial_condition_perturbation : bool, optional
-        Whether to get perturbed initial conditions, by default False
-        If False, only one initial condition is returned, and
-        the ensemble members are simulated by wrapping the action.
     payload_metadata : Optional[dict[str, Any]], optional
         Metadata to add to the payload, by default None
 
@@ -91,69 +86,42 @@ def _get_initial_conditions_source(
     else:
         config_dict = config
 
+    if ensemble_members is None:
+        ensemble_members = [0]
+
     ens_members = parse_ensemble_members(ensemble_members)
-    if initial_condition_perturbation:
-        if any(ens is None for ens in ens_members):
-            raise ValueError("Ensemble members must be specified when using initial condition perturbation.")
-        if isinstance(config_dict, fluent.Action):
-            init_conditions = config_dict.transform(
-                lambda x, *a: x.map(
-                    fluent.Payload(
-                        "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions",
-                        args=(fluent.Node.input_name(0)),
-                        kwargs=dict(number=a[0], date=date),
-                        metadata=payload_metadata,
-                    )
-                ),
-                params=ens_members,
-                dim=(ENSEMBLE_DIMENSION_NAME, ens_members),
-            )
-            init_conditions._add_dimension("date", [to_datetime(date)])
-            return init_conditions
 
-        return fluent.from_source(
-            [
-                [
-                    fluent.Payload(
-                        "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions",
-                        kwargs=dict(config=config_dict, date=date, number=ens_mem),
-                        metadata=payload_metadata,
-                    )
-                    for ens_mem in ens_members
-                ],
-            ],  # type: ignore
-            coords={"date": [to_datetime(date)], ENSEMBLE_DIMENSION_NAME: ens_members},
-        )
-
+    if any(ens is None for ens in ens_members):
+        raise ValueError("Ensemble members must be specified when using initial condition perturbation.")
     if isinstance(config_dict, fluent.Action):
-        init_condition = fluent.Payload(
-            "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions",
-            args=(fluent.Node.input_name(0),),
-            kwargs=dict(date=date),
-            metadata=payload_metadata,
+        init_conditions = config_dict.transform(
+            lambda x, *a: x.map(
+                fluent.Payload(
+                    "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions",
+                    args=(fluent.Node.input_name(0)),
+                    kwargs=dict(number=a[0], date=date),
+                    metadata=payload_metadata,
+                )
+            ),
+            params=ens_members,
+            dim=(ENSEMBLE_DIMENSION_NAME, ens_members),
         )
-        single_init = config_dict.map(init_condition)
-        single_init._add_dimension("date", [to_datetime(date)])
-    else:
-        init_condition = fluent.Payload(
-            "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions",
-            kwargs=dict(config=config_dict, date=date),
-            metadata=payload_metadata,
-        )
-        single_init = fluent.from_source(
-            [
-                init_condition,
-            ],  # type: ignore
-            coords={"date": [to_datetime(date)]},
-        )
+        init_conditions._add_dimension("date", [to_datetime(date)])
+        return init_conditions
 
-    # Wrap with empty payload to simulate ensemble members
-    expanded_init = single_init.transform(
-        faked_ensemble_transform,
-        list(zip(ens_members)),
-        (ENSEMBLE_DIMENSION_NAME, ens_members),  # type: ignore
+    return fluent.from_source(
+        [
+            [
+                fluent.Payload(
+                    "earthkit.workflows.plugins.anemoi.inference._get_initial_conditions",
+                    kwargs=dict(config=config_dict, date=date, number=ens_mem),
+                    metadata=payload_metadata,
+                )
+                for ens_mem in ens_members
+            ],
+        ],  # type: ignore
+        coords={"date": [to_datetime(date)], ENSEMBLE_DIMENSION_NAME: ens_members},
     )
-    return expanded_init
 
 
 def _run_model(
@@ -355,8 +323,6 @@ class Inference:
     def from_initial_conditions(
         self,
         initial_conditions: dict[str, State] | None | fluent.Action | fluent.Payload | Callable,
-        *,
-        ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
         **kwargs: Any,
     ) -> fluent.Action:
         """
@@ -370,11 +336,6 @@ class Inference:
             None creates a source node that yields None.
             If a fluent action and multiple ensemble member initial conditions
             are included, the dimension must be named `ensemble_member`.
-        ensemble_members : Optional[ENSEMBLE_MEMBER_SPECIFICATION], optional
-            Number of ensemble members to run.
-            If initial_conditions is a fluent action with multiple ensemble
-            members, this argument can be set to None, and the number of
-            ensemble members will be inferred from the action.
         kwargs : dict
             Additional arguments to pass to the runner configuration
 
@@ -641,6 +602,7 @@ def get_initial_conditions(
     ckpt: VALID_CKPT,
     input: str | dict[str, Any],
     date: DATE,
+    ensemble_members: ENSEMBLE_MEMBER_SPECIFICATION | None = None,
     *,
     environment: ENVIRONMENT | None = None,
     **kwargs: Any,
@@ -674,6 +636,10 @@ def get_initial_conditions(
         Date for the initial conditions. Can be a ``datetime.datetime``,
         an ISO 8601 string (e.g. ``"2021-01-01T00:00:00"``), or a
         ``(year, month, day)`` tuple.
+    ensemble_members : ENSEMBLE_MEMBER_SPECIFICATION, optional
+        Number of ensemble members to retrieve, or specification of which members to retrieve.
+        This can be set to None to retrieve a single member, or to a specification (e.g. an int for number of members, or a list of member identifiers) to retrieve multiple members.
+        By default, None (retrieves a single member if supported).
     environment : ENVIRONMENT, optional
         Environment to run the initial conditions retrieval in, by default None.
         If None, will use the current environment.
@@ -719,6 +685,7 @@ def get_initial_conditions(
     return _get_initial_conditions_source(
         config=config,
         date=date,
+        ensemble_members=ensemble_members,
         payload_metadata={"environment": environment_dict["initial_conditions"]},
     )
 

--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -40,7 +40,12 @@ def _get_initial_conditions(config: dict, date: DATE, number: int | None = None)
     def _mars_kwargs(input_obj):
         if isinstance(input_obj, MarsInput) and number is not None:
             return {"number": number}
-        return {}
+        elif number is not None:
+            raise ValueError(
+                f"Ensemble member specification provided but input {input_obj} is not a MarsInput, unable to apply ensemble member specification"
+            )
+        else:
+            return {}
 
     for key in runner.dataset_names:
         dt = to_datetime(date)

--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -33,6 +33,7 @@ def _get_initial_conditions(config: dict, date: DATE, number: int | None = None)
     runner = CascadeRunner(**config)
 
     states = {}
+    from anemoi.inference.inputs.empty import EmptyInput
     from anemoi.inference.inputs.mars import MarsInput
 
     # TODO: Replace with a prefetch of all data in the case of dynamics and model uses GribInput during run
@@ -40,6 +41,8 @@ def _get_initial_conditions(config: dict, date: DATE, number: int | None = None)
     def _mars_kwargs(input_obj):
         if isinstance(input_obj, MarsInput) and number is not None:
             return {"number": number}
+        elif isinstance(input_obj, EmptyInput):
+            return {}
         elif number is not None:
             raise ValueError(
                 f"Ensemble member specification provided but input {input_obj} is not a MarsInput, unable to apply ensemble member specification"

--- a/tests/integration/test_data_flows.py
+++ b/tests/integration/test_data_flows.py
@@ -117,15 +117,6 @@ class TestDataFlows:
     # --- Inference class: from_initial_conditions ---
 
     @fake_checkpoints
-    def test_inference_from_initial_conditions_none(self, simple_ckpt_path):
-        """Inference.from_initial_conditions(None) should build a valid graph."""
-        inference = Inference(simple_ckpt_path, lead_time="1D")
-        action = inference.from_initial_conditions(None, ensemble_members=2)
-        graph = action.graph()
-        assert not graph.has_cycle()
-        assert ENSEMBLE_DIMENSION_NAME in action.nodes.dims
-
-    @fake_checkpoints
     def test_inference_from_initial_conditions_action(self, simple_ckpt_path):
         """Inference.from_initial_conditions with a fluent.Action should chain correctly."""
         init = fluent.from_source(

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -131,10 +131,10 @@ def test_from_initial_conditions_from_none(ckpt, ensemble_members, kwargs, shape
     ckpt_full_path = (Path(__file__).parent / f"checkpoints/{ckpt}.yaml").absolute()
     kwargs = kwargs.copy()
     shape = shape.copy()
-    kwargs.pop("date", None)
 
-    action = from_initial_conditions(ckpt_full_path, None, ensemble_members=ensemble_members, **kwargs)
+    action = from_initial_conditions(ckpt_full_path, None, **kwargs)
     shape.pop("date", None)
+    shape.pop(ENSEMBLE_DIMENSION_NAME, None)
     assert_shape(action, shape)
 
 
@@ -151,8 +151,9 @@ def test_inference_from_initial_conditions_from_none(ckpt, ensemble_members, kwa
     kwargs.pop("date", None)
 
     inference = Inference(ckpt_full_path, lead_time=kwargs.pop("lead_time"))
-    action = inference.from_initial_conditions(None, ensemble_members=ensemble_members, **kwargs)
+    action = inference.from_initial_conditions(None, **kwargs)
     shape.pop("date", None)
+    shape.pop(ENSEMBLE_DIMENSION_NAME, None)
     assert_shape(action, shape)
 
 
@@ -176,11 +177,11 @@ def test_from_initial_conditions_with_no_checkpoint_file(ckpt, ensemble_members,
     action = from_initial_conditions(
         "non_existent_checkpoint.ckpt",
         None,
-        ensemble_members=ensemble_members,
         metadata=metadata,
         **kwargs,
     )
     shape.pop("date", None)
+    shape.pop(ENSEMBLE_DIMENSION_NAME, None)
     assert_shape(action, shape)
 
 
@@ -338,7 +339,7 @@ def test_from_initial_conditions_with_dict_metadata(dict_metadata: dict) -> None
         date="2020-01-01",
         lead_time="1D",
     )
-    assert_shape(action, {"step": 4, ENSEMBLE_DIMENSION_NAME: 1, "param": 6})
+    assert_shape(action, {"step": 4, "param": 6})
 
 
 def test_from_input_with_dict_metadata(dict_metadata: dict) -> None:
@@ -349,6 +350,7 @@ def test_from_input_with_dict_metadata(dict_metadata: dict) -> None:
         metadata=dict_metadata,
         date="2020-01-01",
         lead_time="1D",
+        ensemble_members=1,
     )
     assert_shape(action, {"step": 4, ENSEMBLE_DIMENSION_NAME: 1, "param": 6, "date": 1})
 
@@ -360,7 +362,7 @@ def test_inference_class_with_dict_metadata(dict_metadata: dict) -> None:
     inference = Inference(ckpt, lead_time=SIMPLE_KWARGS["lead_time"], metadata=dict_metadata)
     action = inference.from_initial_conditions(None, payload_metadata=PAYLOAD_METADATA)
     assert_payload_metadata(action, PAYLOAD_METADATA)
-    assert_shape(action, {"step": 4, ENSEMBLE_DIMENSION_NAME: 1})
+    assert_shape(action, {"step": 4})
 
 
 def test_inference_class_with_expansion_qube(dict_metadata: dict) -> None:

--- a/tests/test_fluent_helpers.py
+++ b/tests/test_fluent_helpers.py
@@ -14,24 +14,26 @@ from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
 
 
 @pytest.mark.parametrize(
-    "date, ensemble_members, perturbation, shape",
+    "date, ensemble_members, shape",
     [
-        ["2000-01-01", 1, False, {"date": 1}],
-        ["2000-01-01", [2], False, {"date": 1}],
-        ["2000-01-01", range(1, 2), False, {"date": 1}],
-        ["2000-01-01", 10, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", range(10), False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", range(10, 20), False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", 10, True, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", 51, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
-        ["2000-01-01", 51, True, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
-        [-1, 51, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
+        ["2000-01-01", 1, {"date": 1}],
+        ["2000-01-01", [2], {"date": 1}],
+        ["2000-01-01", range(1, 2), {"date": 1}],
+        ["2000-01-01", 10, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", range(10), {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", range(10, 20), {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", 10, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", 51, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
+        ["2000-01-01", 51, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
+        [-1, 51, {"date": 1, ENSEMBLE_DIMENSION_NAME: 51}],
     ],
 )
-def test_get_initial_conditions_action(mock_config, date, ensemble_members, perturbation, shape):
+def test_get_initial_conditions_action(mock_config, date, ensemble_members, shape):
     """Test getting initial conditions"""
     action = _get_initial_conditions_source(
-        mock_config, date, ensemble_members, initial_condition_perturbation=perturbation
+        mock_config,
+        date,
+        ensemble_members,
     )
 
     for dim in shape:
@@ -40,15 +42,13 @@ def test_get_initial_conditions_action(mock_config, date, ensemble_members, pert
 
 
 @pytest.mark.parametrize(
-    "date, ensemble_members, perturbation, shape",
+    "date, ensemble_members, shape",
     [
-        ["2000-01-01", 0, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
-        ["2000-01-01", -1, False, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", 0, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
+        ["2000-01-01", -1, {"date": 1, ENSEMBLE_DIMENSION_NAME: 10}],
     ],
 )
-def test_get_initial_conditions_action_fail(mock_config, date, ensemble_members, perturbation, shape):
+def test_get_initial_conditions_action_fail(mock_config, date, ensemble_members, shape):
     """Test failing to get initial conditions"""
     with pytest.raises(ValueError):
-        _ = _get_initial_conditions_source(
-            mock_config, date, ensemble_members, initial_condition_perturbation=perturbation
-        )
+        _ = _get_initial_conditions_source(mock_config, date, ensemble_members)


### PR DESCRIPTION
### Description

This pull request refactors how ensemble member handling and initial condition perturbations are managed in the Anemoi plugin's fluent API. The changes simplify the API by removing the `initial_condition_perturbation` parameter, standardising the way ensemble members are specified, and updating both the implementation and tests to match this new approach. The result is a more consistent and less error-prone interface for specifying ensemble members in workflows.

**API Simplification and Refactoring:**

* Removed the `initial_condition_perturbation` parameter from `_get_initial_conditions_source` and related functions, streamlining ensemble member specification to rely solely on the `ensemble_members` argument. [[1]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL61) [[2]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL76-L79) [[3]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daR89-R93)
* Simplified the logic for generating initial conditions, eliminating the need to simulate ensemble members via payload transforms and instead handling ensemble member expansion directly based on the `ensemble_members` argument. [[1]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL128-L159) [[2]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL407-R368)

**Interface and Documentation Updates:**

* Updated function signatures and docstrings for `get_initial_conditions` and `from_initial_conditions` to reflect the new, simplified ensemble member handling. [[1]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL360-L361) [[2]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daL375-L379) [[3]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daR605) [[4]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daR639-R642) [[5]](diffhunk://#diff-aaf073f3603807489aa399a8cfa315a5f2dbd7bb3168f36679955a1e19e2e0daR688)

**Test Adjustments:**

* Refactored tests to remove references to `initial_condition_perturbation`, update expected shapes, and ensure correct handling of ensemble member dimensions in both integration and unit tests. [[1]](diffhunk://#diff-08350384e6059fe7e33087994c10dbd53929f61bc77e4f6fefc5f9cf40ade71aL119-L127) [[2]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L134-R137) [[3]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L154-R156) [[4]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L179-R184) [[5]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L341-R342) [[6]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0R353) [[7]](diffhunk://#diff-00518b6a0cf346fc5f025b5d8d0eb51a94686ae1f91d72672b51533a9b59b9d0L363-R365) [[8]](diffhunk://#diff-f34991cd234fec59125a8006b4620cf99113c6f1e834cf96d1370dec68d18f43L17-R36) [[9]](diffhunk://#diff-f34991cd234fec59125a8006b4620cf99113c6f1e834cf96d1370dec68d18f43L43-R54)

**Internal Logic Improvements:**

* Improved error handling in `_get_initial_conditions` (in `inference.py`) to better validate ensemble member specifications and provide clearer error messages for unsupported input types.

These changes collectively make the workflow API easier to use and maintain, reducing ambiguity around ensemble member specification and ensuring consistent behaviour across the codebase.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
