### PR TITLE
chore: Various fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [ "version" ]
 dependencies = [
   "anemoi-utils",
   "earthkit-workflows>=0.7",
-  "qubed>=0.3",
+  "qubed>=0.3,<0.4.4",
 ]
 optional-dependencies.docs = [
   "autodoc-pydantic",

--- a/src/earthkit/workflows/plugins/anemoi/inference.py
+++ b/src/earthkit/workflows/plugins/anemoi/inference.py
@@ -33,9 +33,9 @@ def _get_initial_conditions(config: dict, date: DATE, number: int | None = None)
     runner = CascadeRunner(**config)
 
     states = {}
+    from anemoi.inference.inputs.cutout import Cutout
     from anemoi.inference.inputs.empty import EmptyInput
     from anemoi.inference.inputs.mars import MarsInput
-    from anemoi.inference.inputs.cutout import Cutout
 
     # TODO: Replace with a prefetch of all data in the case of dynamics and model uses GribInput during run
     # Use pipes to read and write

--- a/src/earthkit/workflows/plugins/anemoi/runner.py
+++ b/src/earthkit/workflows/plugins/anemoi/runner.py
@@ -69,7 +69,12 @@ class CascadeOutput(Output):
         try:
             grib_memory = BytesIO()
             grib_output = GribMemoryOutput(
-                self.context, self.metadata, out=grib_memory, templates=self._templates, encoding=grib_metadata, check_encoding = False
+                self.context,
+                self.metadata,
+                out=grib_memory,
+                templates=self._templates,
+                encoding=grib_metadata,
+                check_encoding=False,
             )
             grib_output.write_state(state)
             grib_memory.seek(0, 0)

--- a/src/earthkit/workflows/plugins/anemoi/runner.py
+++ b/src/earthkit/workflows/plugins/anemoi/runner.py
@@ -69,7 +69,7 @@ class CascadeOutput(Output):
         try:
             grib_memory = BytesIO()
             grib_output = GribMemoryOutput(
-                self.context, self.metadata, out=grib_memory, templates=self._templates, encoding=grib_metadata
+                self.context, self.metadata, out=grib_memory, templates=self._templates, encoding=grib_metadata, check_encoding = False
             )
             grib_output.write_state(state)
             grib_memory.seek(0, 0)


### PR DESCRIPTION
### Description
This pull request introduces a version pin for the `qubed` dependency and modifies the behavior of GRIB output encoding in the `anemoi` plugin runner. These changes help ensure compatibility and provide more control over the encoding process.

**Dependency management:**

* Restricts the `qubed` dependency to versions `>=0.3` and `<0.4.4` in `pyproject.toml` to prevent issues with newer, incompatible versions.

**Plugin runner behavior:**

* Updates `GribMemoryOutput` initialization in `runner.py` to set `check_encoding=False`, disabling encoding checks during GRIB output writing.
* 
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
